### PR TITLE
GUI improvements

### DIFF
--- a/otau_model.cpp
+++ b/otau_model.cpp
@@ -54,11 +54,14 @@ QVariant OtauModel::headerData(int section, Qt::Orientation orientation, int rol
         case SectionAddress:
             return tr("Address");
 
-        case SectionSoftwareVersion:
-            return tr("Version");
+        case SectionManufacturer:
+            return tr("Mf");
 
         case SectionImageType:
             return tr("Image");
+
+        case SectionSoftwareVersion:
+            return tr("Version");
 
         case SectionProgress:
             return tr("Progress");
@@ -104,12 +107,17 @@ QVariant OtauModel::data(const QModelIndex &index, int role) const
             }
             break;
 
-        case SectionSoftwareVersion:
-            str = "0x" + QString("%1").arg(node->softwareVersion(), 8, 16, QLatin1Char('0'));
+        case SectionManufacturer:
+            str = "0x" + QString("%1").arg(node->manufacturerId, 4, 16, QLatin1Char('0'));
             break;
+
 
         case SectionImageType:
             str = "0x" + QString("%1").arg(node->imageType(), 4, 16, QLatin1Char('0'));
+            break;
+
+        case SectionSoftwareVersion:
+            str = "0x" + QString("%1").arg(node->softwareVersion(), 8, 16, QLatin1Char('0'));
             break;
 
         case SectionProgress:
@@ -221,8 +229,9 @@ QVariant OtauModel::data(const QModelIndex &index, int role) const
         switch (index.column())
         {
         case SectionAddress:
-        case SectionSoftwareVersion:
+        case SectionManufacturer:
         case SectionImageType:
+        case SectionSoftwareVersion:
         {
             QFont font("Monospace");
             font.setStyleHint(QFont::TypeWriter);

--- a/otau_model.h
+++ b/otau_model.h
@@ -19,8 +19,9 @@ public:
     enum Section
     {
         SectionAddress = 0,
-        SectionSoftwareVersion,
+        SectionManufacturer,
         SectionImageType,
+        SectionSoftwareVersion,
         SectionProgress,
         SectionDuration,
 //        SectionStatus,
@@ -40,7 +41,7 @@ public:
     void nodeDataUpdate(OtauNode *node);
     std::vector<OtauNode *> &nodes();
 signals:
-    
+
 public slots:
 private:
     std::vector<OtauNode*> m_nodes;

--- a/otau_node.cpp
+++ b/otau_node.cpp
@@ -24,6 +24,7 @@ OtauNode::OtauNode(const deCONZ::Address &addr)
     m_status = StatusSuccess;
     apsRequestId = 0xff + 1; // invalid > 8-bit
     profileId = HA_PROFILE_ID;
+    manufacturerId = 0;
     endpoint = 0xFF; // for unicast if endpoint not known
     rxOnWhenIdle = true;
 }

--- a/std_otau_plugin.cpp
+++ b/std_otau_plugin.cpp
@@ -431,7 +431,7 @@ void StdOtauPlugin::apsdeDataConfirm(const deCONZ::ApsDataConfirm &conf)
  */
 void StdOtauPlugin::nodeEvent(const deCONZ::NodeEvent &event)
 {
-    if (!event.node())
+    if (event.event() != deCONZ::NodeEvent::NodeDeselected && !event.node())
     {
         return;
     }
@@ -439,6 +439,35 @@ void StdOtauPlugin::nodeEvent(const deCONZ::NodeEvent &event)
     if (event.event() == deCONZ::NodeEvent::UpdatedSimpleDescriptor)
     {
         checkIfNewOtauNode(event.node(), event.endpoint());
+    }
+    else if (event.event() == deCONZ::NodeEvent::NodeSelected)
+    {
+        nodeSelected(event.node());
+    }
+    else if (event.event() == deCONZ::NodeEvent::NodeDeselected)
+    {
+        m_w->clearNode();
+    }
+    else if (event.event() == deCONZ::NodeEvent::NodeRemoved)
+    {
+        // TODO: Remove node from model and tableview
+    }
+}
+
+void StdOtauPlugin::nodeSelected(const deCONZ::Node *node)
+{
+    if (!m_model || m_model->nodes().empty())
+    {
+        return;
+    }
+    OtauNode *otauNode = m_model->getNode(node->address());
+    if (otauNode != nullptr)
+    {
+        m_w->displayNode(otauNode, m_model->index(otauNode->row, 0));
+    }
+    else
+    {
+        m_w->clearNode();
     }
 }
 

--- a/std_otau_plugin.h
+++ b/std_otau_plugin.h
@@ -83,6 +83,7 @@ public Q_SLOTS:
     bool upgradeEndResponse(OtauNode *node, uint32_t upgradeTime);
     bool defaultResponse(OtauNode *node, quint8 commandId, quint8 status);
     void nodeEvent(const deCONZ::NodeEvent &event);
+    void nodeSelected(const deCONZ::Node *node);
     bool checkForUpdateImageImage(OtauNode *node, const QString &path);
     void invalidateUpdateEndRequest(OtauNode *node);
     void delayedImageNotify();

--- a/std_otau_widget.cpp
+++ b/std_otau_widget.cpp
@@ -73,11 +73,16 @@ void StdOtauWidget::setOtauModel(OtauModel *model)
         {
             // adjust columns
             ui->tableView->resizeColumnToContents(OtauModel::SectionAddress);
-            ui->tableView->resizeColumnToContents(OtauModel::SectionSoftwareVersion);
+            ui->tableView->resizeColumnToContents(OtauModel::SectionManufacturer);
             ui->tableView->resizeColumnToContents(OtauModel::SectionImageType);
+            ui->tableView->resizeColumnToContents(OtauModel::SectionSoftwareVersion);
+            ui->tableView->resizeColumnToContents(OtauModel::SectionProgress);
+            ui->tableView->resizeColumnToContents(OtauModel::SectionDuration);
         }
 
         ui->tableView->isSortingEnabled();
+        ui->tableView->sortByColumn(0, Qt::AscendingOrder);
+
     });
 }
 
@@ -221,6 +226,7 @@ void StdOtauWidget::clearSettingsBox()
     ui->ou_fileVersionEdit->setText("0x00000000");
     ui->ou_fileVersionEdit->setToolTip(QString());
     ui->ou_imageTypeEdit->setText("0x0000");
+    ui->ou_manufacturerEdit->setText("0x0000");
     ui->ou_SizeEdit->setText("0x00000000");
 }
 
@@ -385,8 +391,18 @@ void StdOtauWidget::displayNode(OtauNode *node)
         ui->lastQueryLabel->setText(tr("None"));
         clearSettingsBox();
     }
+}
 
+void StdOtauWidget::displayNode(OtauNode *node, const QModelIndex &index)
+{
+    ui->tableView->selectRow(proxyModel->mapFromSource(index).row());
+    displayNode(node);
+}
 
+void StdOtauWidget::clearNode()
+{
+    ui->tableView->clearSelection();
+    displayNode(nullptr);
 }
 
 void StdOtauWidget::updateEditor()

--- a/std_otau_widget.h
+++ b/std_otau_widget.h
@@ -20,7 +20,7 @@ class QSortFilterProxyModel;
 class StdOtauWidget : public QWidget
 {
     Q_OBJECT
-    
+
 public:
     explicit StdOtauWidget(QWidget *parent);
     ~StdOtauWidget();
@@ -49,6 +49,8 @@ public Q_SLOTS:
     void saveAsClicked();
     void openClicked();
     void displayNode(OtauNode *node);
+    void displayNode(OtauNode *node, const QModelIndex &index);
+    void clearNode();
 
 Q_SIGNALS:
     void broadcastImageNotify();

--- a/std_otau_widget.ui
+++ b/std_otau_widget.ui
@@ -81,10 +81,72 @@
        </item>
        <item>
         <layout class="QGridLayout" name="gridLayout_2">
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_11">
+           <property name="text">
+            <string>Manufacturer Id</string>
+           </property>
+           <property name="buddy">
+            <cstring>ou_manufacturerEdit</cstring>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QLineEdit" name="ou_manufacturerEdit">
+           <property name="inputMask">
+            <string>\0\xHHHHHHHH</string>
+           </property>
+           <property name="text">
+            <string>0x0000</string>
+           </property>
+           <property name="readOnly">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="2">
+          <widget class="QLabel" name="label_2">
+           <property name="text">
+            <string>Image Type</string>
+           </property>
+           <property name="buddy">
+            <cstring>ou_imageTypeEdit</cstring>
+           </property>
+          </widget>
+         </item>
          <item row="0" column="3" colspan="2">
-          <widget class="QLineEdit" name="ou_SizeEdit">
+          <widget class="QLineEdit" name="ou_imageTypeEdit">
            <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Size of OTAU file including header.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The otau client might use the image type as additional filter to accept or deny a otau image.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="inputMask">
+            <string>\0\xHHHHHHHH</string>
+           </property>
+           <property name="text">
+            <string>0x0000</string>
+           </property>
+           <property name="readOnly">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label">
+           <property name="text">
+            <string>File Version</string>
+           </property>
+           <property name="buddy">
+            <cstring>ou_fileVersionEdit</cstring>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QLineEdit" name="ou_fileVersionEdit">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="inputMask">
+            <string>\0\xHHHHHHHH</string>
            </property>
            <property name="text">
             <string>0x00000000</string>
@@ -94,13 +156,26 @@
            </property>
           </widget>
          </item>
-         <item row="1" column="2" colspan="2">
-          <widget class="QLabel" name="label_11">
+         <item row="1" column="2">
+          <widget class="QLabel" name="label_12">
            <property name="text">
-            <string>Manufacturer Id</string>
+            <string>Size</string>
            </property>
            <property name="buddy">
-            <cstring>ou_manufacturerEdit</cstring>
+            <cstring>ou_SizeEdit</cstring>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="3" colspan="2">
+          <widget class="QLineEdit" name="ou_SizeEdit">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Size of OTAU file including header.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>0x00000000</string>
+           </property>
+           <property name="readOnly">
+            <bool>true</bool>
            </property>
           </widget>
          </item>
@@ -117,69 +192,10 @@
            </property>
           </widget>
          </item>
-         <item row="0" column="0">
-          <widget class="QLabel" name="label">
-           <property name="text">
-            <string>File Version</string>
-           </property>
-           <property name="buddy">
-            <cstring>ou_fileVersionEdit</cstring>
-           </property>
-          </widget>
-         </item>
          <item row="3" column="0">
           <widget class="QLabel" name="label_13">
            <property name="text">
             <string>Last Image Query</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="2">
-          <widget class="QLabel" name="label_12">
-           <property name="text">
-            <string>Size</string>
-           </property>
-           <property name="buddy">
-            <cstring>ou_SizeEdit</cstring>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QLabel" name="label_2">
-           <property name="text">
-            <string>Image Type</string>
-           </property>
-           <property name="buddy">
-            <cstring>ou_imageTypeEdit</cstring>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="4">
-          <widget class="QLineEdit" name="ou_manufacturerEdit">
-           <property name="inputMask">
-            <string>\0\xHHHHHHHH</string>
-           </property>
-           <property name="text">
-            <string>0x1135</string>
-           </property>
-           <property name="readOnly">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QLineEdit" name="ou_fileVersionEdit">
-           <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-           </property>
-           <property name="inputMask">
-            <string>\0\xHHHHHHHH</string>
-           </property>
-           <property name="text">
-            <string>0x00000000</string>
-           </property>
-           <property name="readOnly">
-            <bool>true</bool>
            </property>
           </widget>
          </item>
@@ -226,22 +242,6 @@
            </property>
            <property name="value">
             <number>5</number>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="QLineEdit" name="ou_imageTypeEdit">
-           <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The otau client might use the image type as additional filter to accept or deny a otau image.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-           </property>
-           <property name="inputMask">
-            <string>\0\xHHHHHHHH</string>
-           </property>
-           <property name="text">
-            <string>0x0000</string>
-           </property>
-           <property name="readOnly">
-            <bool>true</bool>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
Several enhancements to the _OTAU Update_ tab in the GUI:
- Sort the table by _Address_ on startup;
- Add _Manufacturer ID_ to the table;
- Change table column order to _Manufacturer ID_, _Image Type_, _Version_;
- Size all table columns;
- Change order of file attributes* to _Manufacturer ID_, _Image Type_, _Version_;
- Set file _Manufacturer ID_ to 0x0000 when no file loaded for selected table entry (or no table entry selected);
- (De)select corresponding table entry when (de)selecting node on the map.

I'm particularly happy about the last point.  If this is working out, I'd like to do the same with the _Node Info_ panel of the REST API plugin.

*) I hacked `std_otau_widget.ui` manually to change the order of the file attributes.  I would expect you have an IDE to maintain this file?  Or is it generated?  In that case, the generator source might need to be updated.

Still todo:
- When node is deleted from the map, delete corresponding table entry;
- Apply similar changes to the _OTAU File_ tab.  I don't think it handles the Hue files with illegal segment tag and length correctly.  Is this functionality actually used?  Or can it be removed?