### PR TITLE
Ignore useless bad data at the end of file

### DIFF
--- a/otau_file.cpp
+++ b/otau_file.cpp
@@ -247,6 +247,14 @@ bool OtauFile::fromArray(const QByteArray &arr)
         {
             DBG_Printf(DBG_OTA, "OTAU:   offset %6u: ignore tag 0x%04X with invalid length\n", start, sub.tag);
         }
+
+        // Total data process = totalImageSize, skip next segments, used only for legrand ATM
+        if ((manufacturerCode == 0x1021) && (processedLength == totalImageSize))
+        {
+            DBG_Printf(DBG_OTA, "OTAU:   Total Image size reached, skip next segments\n");
+            break;
+        }
+
     }
     if (!stream.atEnd())
     {


### PR DESCRIPTION
I have activated this modification only for Legrand, but I think it will works too for other manufacture (I have see same problem on ikea firmware)

Easy to understand what it do, an exemple of legrand firmware

```
File name : NLF-43.ota
File size : 231068 Bytes
find start offset : 4

**** HEADER ***
Upgrade File identifier : 0xbeef11e
Header version : 0x100
Header lenght : 56
Header field control : 0
Manufacturer code : 0x1021
Image type : 0xe Manfufacturer Specific
File version : 0x2b0000 > App release:0 App Build:0 Stack release:43 Stack Build:0
zigbee stack version: 0x2
Header string: b'                                '
Total image size: 231047
No special headers

***** DATA ***** (Start at offset 60)

Segment 1
-------------
Tag ID : 0x0 Upgrade Image
len field : 230985 bytes
segment offset 60>231050 (230991 bytes)
Image percentage 100.0%

*** IMAGE COMPLETE ***

Segment 2
-------------
Tag ID : 0x3000 Reserved
*** Recalculating lenght, value in TAG too big = 782725238
segment offset 231051>231067 (17 bytes)

**** END ********
Unused data : 0
```