### PR TITLE
Fix update with modern ota files

### DIFF
--- a/otau_file.h
+++ b/otau_file.h
@@ -4,7 +4,7 @@
 #include <stdint.h>
 #include <QtGlobal>
 #include <QByteArray>
-#include <list>
+#include <vector>
 
 //!< Header field control bits
 #define OF_FC_SECURITY_CREDENTIAL_VERSION 0x0001
@@ -84,7 +84,7 @@ struct OtauFile
     uint16_t minHardwareVersion;
     uint16_t maxHardwareVersion;
 
-    std::list<SubElement> subElements;
+    std::vector<SubElement> subElements;
     QByteArray raw;
 };
 

--- a/otau_node.h
+++ b/otau_node.h
@@ -131,7 +131,6 @@ public:
     uint8_t reqSequenceNumber;
     uint16_t profileId;
     uint16_t manufacturerId;
-    uint8_t maxDataSize;
     uint32_t imageSize;
     uint8_t *imageData;
     uint32_t timeout; // seconds

--- a/std_otau_widget.cpp
+++ b/std_otau_widget.cpp
@@ -306,8 +306,8 @@ void StdOtauWidget::saveClicked()
     //  preserve sub element "upgrade image"
     OtauFile::SubElement subImage;
     {
-        std::list<OtauFile::SubElement>::iterator it = m_editOf.subElements.begin();
-        std::list<OtauFile::SubElement>::iterator end = m_editOf.subElements.end();
+        auto it = m_editOf.subElements.begin();
+        auto end = m_editOf.subElements.end();
 
         for (;it != end; ++it)
         {
@@ -446,21 +446,6 @@ void StdOtauWidget::updateEditor()
     str = "0x" + QString("%1").arg(m_editOf.maxHardwareVersion, 4, 16, QLatin1Char('0')).toUpper();
     ui->of_maxHwVersionEdit->setText(str);
 
-    // standard 0
-    str = "0x" + QString("%1").arg(0, 8, 16, QLatin1Char('0')).toUpper();
+    str = QString::number(m_editOf.totalImageSize);
     ui->of_firmwareSizeEdit->setText(str);
-
-    {
-        std::list<OtauFile::SubElement>::iterator it = m_editOf.subElements.begin();
-        std::list<OtauFile::SubElement>::iterator end = m_editOf.subElements.end();
-
-        for (;it != end; ++it)
-        {
-            if (it->tag == TAG_UPGRADE_IMAGE)
-            {
-                str = "0x" + QString("%1 (%2 kB)").arg(it->length, 8, 16, QLatin1Char('0')).arg(it->length / 1024).toUpper();
-                ui->of_firmwareSizeEdit->setText(str);
-            }
-        }
-    }
 }


### PR DESCRIPTION
- Fix Ikea Tradfri Repeater update https://github.com/dresden-elektronik/deconz-ota-plugin/issues/37
- Fix loading OTA  files of new Ledvance products.
- The problem was fixed by using the original file content for transfers. Prior the content was parsed and rebuild which lost some sub tagged areas of recent OTA files.
- Reduce dependencies on file extensions, test for valid OTA content.
- Cap max data size to 50 to support a wider range of devices and fallback to 40 bytes in error cases. The plain source route capping before didn't work out in some cases.