### PR TITLE
Support OTA file downloads and simplified UI

### DIFF
--- a/otau_model.cpp
+++ b/otau_model.cpp
@@ -121,11 +121,7 @@ QVariant OtauModel::data(const QModelIndex &index, int role) const
             break;
 
         case SectionProgress:
-            if (node->status() == OtauNode::StatusWaitUpgradeEnd)
-            {
-                str = tr("Wait to finish");
-            }
-            else if (node->zclCommandId == OTAU_UPGRADE_END_RESPONSE_CMD_ID)
+            if (node->status() == OtauNode::StatusUpgradeEnd)
             {
                 switch(node->upgradeEndReq.status)
                 {
@@ -138,18 +134,7 @@ QVariant OtauModel::data(const QModelIndex &index, int role) const
                     break;
                 }
             }
-            else if (node->zclCommandId == OTAU_QUERY_NEXT_IMAGE_RESPONSE_CMD_ID)
-            {
-                if (node->hasData())
-                {
-                    str = tr("Idle");
-                }
-                else
-                {
-                    str = tr("No file");
-                }
-            }
-            else if (node->permitUpdate())
+            else if (node->status() == OtauNode::StatusUploading)
             {
                 if (node->offset() > 0)
                 {
@@ -167,9 +152,23 @@ QVariant OtauModel::data(const QModelIndex &index, int role) const
                     str = tr("Queued");
                 }
             }
-            else if (node->hasData())
+            else if (node->status() == OtauNode::StatusImageRequest || node->hasData())
             {
-                str = tr("Paused");
+                if (node->hasData())
+                {
+                    if (node->permitUpdate())
+                    {
+                        str = tr("Queued");
+                    }
+                    else
+                    {
+                        str = tr("Update available");
+                    }
+                }
+                else
+                {
+                    str = tr("No file");
+                }
             }
             else
             {
@@ -184,10 +183,6 @@ QVariant OtauModel::data(const QModelIndex &index, int role) const
             str = QString("%1:%2").arg(min).arg(sec, 2, 10, QLatin1Char('0'));
         }
             break;
-
-//        case SectionStatus:
-//            str = node->statusString();
-//            break;
 
         default:
             break;

--- a/otau_node.cpp
+++ b/otau_node.cpp
@@ -168,7 +168,7 @@ QString OtauNode::statusString() const
     case StatusTimeout: return "Timeout";
     case StatusIgnored: return "Ignored";
     case StatusCrcError: return "CrCError";
-    case StatusWaitUpgradeEnd: return "WaitUpgradeEnd";
+    case StatusUpgradeEnd: return "WaitUpgradeEnd";
     default:
         break;
     }

--- a/otau_node.h
+++ b/otau_node.h
@@ -86,7 +86,9 @@ public:
         StatusTimeout            = 0x08,
         StatusIgnored            = 0x09,
         StatusCrcError           = 0x0A,
-        StatusWaitUpgradeEnd     = 0x0B
+        StatusUpgradeEnd     = 0x0B,
+        StatusUploading          = 0x0C,
+        StatusImageRequest       = 0x0D
     };
 
     OtauNode(const deCONZ::Address &addr);

--- a/std_otau_plugin.cpp
+++ b/std_otau_plugin.cpp
@@ -18,6 +18,7 @@
 #include <deconz/zdp_descriptors.h>
 #include <deconz/zdp_profile.h>
 #include <deconz/node.h>
+#include <deconz/n_downloader.h>
 #include <deconz/util.h>
 #include <deconz/am_vfs.h>
 #include <deconz/u_sha512.h>
@@ -108,12 +109,8 @@
 */
 
 const quint64 macPrefixMask       = 0xffffff0000000000ULL;
-
-// const quint64 develcoMacPrefix    = 0x0015bc0000000000ULL;
-// const quint64 philipsMacPrefix    = 0x0017880000000000ULL;
-// const quint64 ubisysMacPrefix     = 0x001fee0000000000ULL;
 const quint64 osramMacPrefix      = 0x8418260000000000ULL;
-// const quint64 bjeMacPrefix        = 0xd85def0000000000ULL;
+
 
 const deCONZ::SimpleDescriptor *getSimpleDescriptor(const deCONZ::Node *node, quint8 ep)
 {
@@ -248,6 +245,11 @@ StdOtauPlugin::StdOtauPlugin(QObject *parent) :
     connect(m_activityTimer, SIGNAL(timeout()),
             this, SLOT(activityTimerFired()));
 
+    m_downloadTimer = new QTimer(this);
+    m_downloadTimer->setSingleShot(true);
+    connect(m_downloadTimer, SIGNAL(timeout()),
+            this, SLOT(downloadTimerFired()));
+
     //QString defaultImgPath = deCONZ::getStorageLocation(deCONZ::ApplicationsDataLocation) + "/otau";
     QString defaultImgPath = deCONZ::getStorageLocation(deCONZ::HomeLocation) + "/otau";
     m_imgPath = deCONZ::appArgumentString("--otau-img-path", defaultImgPath);
@@ -292,6 +294,38 @@ StdOtauPlugin::StdOtauPlugin(QObject *parent) :
     if (!ok)
     {
         config.setValue("otau/fast-page-spacing", m_fastPageSpaceing);
+    }
+
+    if (config.contains("otau/online-enabled"))
+    {
+        m_downloadsEnabled = config.value("otau/online-enabled", false).toBool();
+    }
+
+    // Koenkk/zigbee-OTA repository is a well maintained source for OTA image files.
+    // The index.json contains links to the files which are also mirrored on Github.
+    /*
+      [{
+        "fileName": "1135-0100-1000002A-Kobold.zigbee",
+        "fileVersion": 268435498,
+        "fileSize": 244094,
+        "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/DresdenElektronik/1135-0100-1000002A-Kobold.zigbee",
+        "imageType": 256,
+        "manufacturerCode": 4405,
+        "sha512": "0905f0e6a469be3893f2c665156f18077258e24439e283c9f4b121553a94e8eb142e6250e721585ddd9aceef75da3c10a03defaee89885d7cb8f08449a20912d",
+        "otaHeaderString": "",
+        "originalUrl": "https://deconz.dresden-elektronik.de/otau/1135-0100-1000002A-Kobold.zigbee"
+      }, {...}]
+
+    */
+    m_downloadIndexUrl = "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/refs/heads/master/index.json";
+    if (config.contains("otau/online-url"))
+    {
+        m_downloadIndexUrl = config.value("otau/online-url", m_downloadIndexUrl).toString();
+    }
+
+    if (m_downloadsEnabled)
+    {
+        m_downloadTimer->start(2000);
     }
 
     checkFileLinks();
@@ -565,8 +599,48 @@ bool StdOtauPlugin::checkForUpdateImageImage(OtauNode *node, const QString &path
         return false;
     }
 
-    bool ok;
     uint32_t cmpFileVersion = node->softwareVersion();
+
+    const QString otaIndexPath = deCONZ::getStorageLocation(deCONZ::ApplicationsDataLocation) + "/ota_index.txt";
+
+    if (!QFile::exists(otaIndexPath))
+        return false;
+
+    {
+        QFile f(otaIndexPath);
+        if (!f.open(QFile::ReadOnly))
+            return false;
+
+            for (;;)
+            {
+                QByteArray line = f.readLine().trimmed();
+                if (line.size() <= 0)
+                    break;
+
+                U_SStream ss;
+                U_sstream_init(&ss, line.data(), line.size());
+
+                long mfcode = U_sstream_get_long(&ss);
+
+                if (mfcode != node->manufacturerId)
+                    continue;
+
+                long imageType = U_sstream_get_long(&ss);
+                if (imageType != node->imageType())
+                    continue;
+
+                long version = U_sstream_get_long(&ss);
+
+                if (ss.status != U_SSTREAM_OK)
+                    continue;
+
+
+
+            }
+    }
+
+    bool ok;
+
     uint32_t fileVersion;
     uint16_t imageType;
     uint16_t manufacturerId;
@@ -799,6 +873,212 @@ void StdOtauPlugin::activityTimerFired()
     }
 }
 
+static void downloadIndexCallback(N_DownloadData *dd)
+{
+    StdOtauPlugin *q = static_cast<StdOtauPlugin*>(dd->user);
+    if (dd->status == N_DownloadDone)
+    {
+        q->onDownloadedIndex(dd->data, dd->data_size);
+    }
+    else
+    {
+        DBG_Printf(DBG_ERROR, "OTAU: error downloading index file (%d)\n", (int)dd->status);
+    }
+}
+
+void StdOtauPlugin::downloadTimerFired()
+{
+    if (m_downloadState == DownloadStateInitial)
+    {
+        if (!m_downloadsEnabled)
+            return;
+
+        if (m_downloadIndexUrl.size() == 0)
+            return;
+
+        m_downloadIndexPath = deCONZ::getStorageLocation(deCONZ::ApplicationsDataLocation) + "/ota_remote_index.json";
+        if (QFile::exists(m_downloadIndexPath))
+        {
+            QFile::remove(m_downloadIndexPath);
+        }
+        m_downloadHandle = N_Download(qPrintable(m_downloadIndexUrl), 1 << 21, downloadIndexCallback, this);
+        m_downloadState = DownloadStateLoadIndex;
+        m_downloadTimer->start(20000);
+    }
+    else if (m_downloadState == DownloadStateLoadIndex)
+    {
+        DBG_Printf(DBG_INFO, "OTAU: failed to download OTA index\n");
+    }
+    else if (m_downloadState == DownloadStateIdle)
+    {
+        struct KOP
+        {
+            uint16_t manufacturerCode;
+            uint16_t imageType;
+            uint32_t fileVersion;
+        };
+
+        std::vector<KOP> known;
+
+        {
+            auto i = m_model->nodes().cbegin();
+            const auto iend = m_model->nodes().cend();
+
+
+            for (; i != iend; ++i)
+            {
+                auto j = known.cbegin();
+                const auto jend = known.cend();
+
+                for (; j != jend; ++j)
+                {
+                    if (j->manufacturerCode != (*i)->manufacturerId)
+                        continue;
+                    if (j->imageType != (*i)->imageType())
+                        continue;
+                    break;
+                }
+
+                if (j == jend)
+                {
+                    KOP entry;
+                    entry.fileVersion = (*i)->file.fileVersion; // needed?
+                    entry.manufacturerCode = (*i)->manufacturerId;
+                    entry.imageType = (*i)->imageType();
+                    known.push_back(entry);
+                }
+            }
+        }
+
+        if (known.empty())
+        {
+            // TODO check later?
+            return;
+        }
+
+        QByteArray data;
+        {
+            QFile f(m_downloadIndexPath);
+            if (f.open(QFile::ReadOnly))
+            {
+                data = f.readAll();
+                if (data.size() == 0 || data.at(0) != '[')
+                    data = {};
+            }
+        }
+
+        // following is a very crude way to parse each JSON object in the large array
+        // it's messy and verbose but also pretty fast
+        U_SStream ss;
+        U_sstream_init(&ss, data.data(), data.size());
+
+        for (;U_sstream_find(&ss, "{");)
+        {
+            unsigned manufacturerCode;
+            unsigned imageType;
+            unsigned fileVersion;
+
+            U_SStream so = ss; // stream limited to one object
+            if (U_sstream_find(&so, "}"))
+            {
+                so.len = so.pos + 1;
+                so.pos = ss.pos;
+                ss.pos = so.len; // advance stream to the next object
+                // 'so' is a string view to the current OTA entry (object)
+            }
+            else
+            {
+                break; // invalid json
+            }
+
+            U_SStream skv; // stream to extract values
+
+            skv = so;
+            if (0 == U_sstream_find(&skv, "manufacturerCode") || 0 == U_sstream_find(&skv, ":"))
+                continue;
+            U_sstream_seek(&skv, skv.pos + 1);
+            manufacturerCode = U_sstream_get_long(&skv);
+
+            skv = so;
+            if (0 == U_sstream_find(&skv, "imageType") || 0 == U_sstream_find(&skv, ":"))
+                continue;
+            U_sstream_seek(&skv, skv.pos + 1);
+            imageType = U_sstream_get_long(&skv);
+
+            skv = so;
+            if (0 == U_sstream_find(&skv, "fileVersion") || 0 == U_sstream_find(&skv, ":"))
+                continue;
+            U_sstream_seek(&skv, skv.pos + 1);
+            fileVersion = U_sstream_get_long(&skv);
+
+            struct DownloadOtaFile
+            {
+                uint16_t manufacturerCode;
+                uint16_t imageType;
+                uint32_t fileVersion;
+                char url[512];
+            };
+
+            auto j = known.cbegin();
+            const auto jend = known.cend();
+
+            for (; j != jend; ++j)
+            {
+                if (j->manufacturerCode == manufacturerCode && j->imageType == imageType)
+                {
+                    DownloadOtaFile dlota;
+
+                    dlota.manufacturerCode = manufacturerCode;
+                    dlota.imageType = imageType;
+
+                    // URL
+                    skv = so;
+                    if (0 == U_sstream_find(&skv, "\"url\"") || 0 == U_sstream_find(&skv, ":") || 0 == U_sstream_find(&skv, "\""))
+                        continue;
+                    U_sstream_seek(&skv, skv.pos + 1);
+                    U_sstream_skip_whitespace(&skv);
+
+                    unsigned pos = skv.pos;
+                    if (0 == U_sstream_find(&skv, "\""))
+                        break;
+
+                    skv.len = skv.pos;
+                    skv.pos = pos;
+
+                    unsigned len = skv.len - skv.pos;
+                    if (len >= sizeof(dlota.url))
+                        break;
+
+                    U_memcpy(dlota.url, &skv.str[skv.pos], len);
+                    dlota.url[len] = '\0';
+
+                    DBG_Printf(DBG_OTA, "OTAU: download %04X-%04X-%08X from %s\n", manufacturerCode, imageType, fileVersion, dlota.url);
+                    break;
+                }
+            }
+        }
+    }
+}
+
+void StdOtauPlugin::onDownloadedIndex(const uint8_t *data, unsigned int size)
+{
+    if (data && 512 < size && m_downloadState == DownloadStateLoadIndex)
+    {
+        DBG_Printf(DBG_OTA, "OTAU: downloaded index file: %u kB\n", size / 1000);
+        QFile f(m_downloadIndexPath);
+        if (f.open(QFile::ReadWrite))
+        {
+            f.write((const char*)data, size);
+            f.close();
+        }
+
+        broadcastImageNotify();
+        m_downloadTimer->stop();
+        m_downloadState = DownloadStateIdle;
+        m_downloadTimer->start(5000);
+    }
+}
+
 void StdOtauPlugin::markOtauActivity(const deCONZ::Address &address)
 {
     if (!address.hasExt())
@@ -829,11 +1109,32 @@ void StdOtauPlugin::markOtauActivity(const deCONZ::Address &address)
     }
 }
 
+struct OtaIndexEntry
+{
+    QString path;
+    uint8_t sha512[U_SHA512_HASH_SIZE];
+    uint32_t mfcode;
+    uint32_t imagetype;
+    uint32_t fileVersion;
+    uint32_t fileSize;
+};
+
 void StdOtauPlugin::checkFileLinks()
 {
+    bool ok;
     QStringList paths;
     paths.append(m_imgPath);
     //paths.append(deCONZ::getStorageLocation(deCONZ::ApplicationsDataLocation) + "/otau");
+
+    QString otaIndexPath = deCONZ::getStorageLocation(deCONZ::ApplicationsDataLocation) + "/ota_index.txt";
+
+    if (QFile::exists(otaIndexPath))
+    {
+        QFile::remove(otaIndexPath);
+    }
+
+    std::vector<OtaIndexEntry> otaEntries;
+    OtaIndexEntry otaEntry;
 
     for (const QString &path : paths)
     {
@@ -865,7 +1166,30 @@ void StdOtauPlugin::checkFileLinks()
                                                      .arg(of.fileVersion, 8, 16, QLatin1Char('0'))
                                                      .toUpper();
 
-            bool ok= false;
+            otaEntry.path = (path + "/" + n);
+            otaEntry.mfcode = of.manufacturerCode;
+            otaEntry.imagetype = of.imageType;
+            otaEntry.fileVersion = of.fileVersion;
+            otaEntry.fileSize = arr.size();
+            U_memset(otaEntry.sha512, 0, sizeof(otaEntry.sha512));
+            U_Sha512(arr.constData(), arr.size(), &otaEntry.sha512[0]);
+
+            ok = false;
+            for (const OtaIndexEntry &e : otaEntries)
+            {
+                if (U_memcmp(e.sha512, otaEntry.sha512, sizeof(e.sha512)) == 0)
+                {
+                    ok = true;
+                    break;
+                }
+            }
+
+            if (!ok)
+            {
+                otaEntries.push_back(otaEntry);
+            }
+
+            ok = false;
             for (const QString &n2 : ls)
             {
                 if (n2.startsWith(fname))
@@ -882,6 +1206,34 @@ void StdOtauPlugin::checkFileLinks()
             file.copy(path + "/" + fname + ".zigbee");
         }
     }
+
+    {
+        QFile otaIndexFile(otaIndexPath);
+        if (otaIndexFile.open(QFile::ReadWrite))
+        {
+            int count = 0;
+            QTextStream stream(&otaIndexFile);
+            stream << "[\n";
+            for (const OtaIndexEntry &e : otaEntries)
+            {
+                if (count)
+                    stream << ",\n";
+
+                stream << "  {\n";
+                stream << "    \"fileVersion\": " << e.fileVersion << ",\n";
+                stream << "    \"fileSize\": " << e.fileSize << ",\n";
+                stream << "    \"manufacturerCode\": " << e.mfcode << ",\n";
+                stream << "    \"imageType\": " << e.imagetype << ",\n";
+                stream << "    \"url\": \"" << e.path << "\"\n";
+                stream << "  }";
+                count++;
+            }
+
+            stream << "\n]\n";
+
+            otaIndexFile.close();
+        }
+    }
 }
 
 /*! Sends a image notify request.
@@ -895,15 +1247,18 @@ bool StdOtauPlugin::imageNotify(ImageNotifyReq *notf)
         deCONZ::ApsDataRequest req;
         deCONZ::ZclFrame zclFrame;
 
-        OtauNode *node = m_model->getNode(notf->addr);
+        OtauNode *node = nullptr;
+
+        if (notf->addrMode == deCONZ::ApsExtAddress)
+            node = m_model->getNode(notf->addr);
 
         req.setDstAddressMode(notf->addrMode);
         req.dstAddress() = notf->addr;
         req.setDstEndpoint(notf->dstEndpoint);
         req.setSrcEndpoint(m_srcEndpoint);
-        req.setTxOptions(deCONZ::ApsTxAcknowledgedTransmission);
         if (node)
         {
+            req.setTxOptions(deCONZ::ApsTxAcknowledgedTransmission);
             req.setProfileId(node->profileId);
             DBG_Printf(DBG_OTA, "OTAU: send img notify to " FMT_MAC "\n", FMT_MAC_CAST(node->address().ext()));
         }

--- a/std_otau_plugin.cpp
+++ b/std_otau_plugin.cpp
@@ -135,7 +135,7 @@ const deCONZ::SimpleDescriptor *getSimpleDescriptor(const deCONZ::Node *node, qu
 #define AM_ACTOR_ID_OTA         9000
 #define AM_ACTOR_ID_CORE_APS    2005
 
-#define OTA_M_ID_QUERY_NEXT_IMAGE_NOTIFY AM_MESSAGE_ID_SPECIFIC_NOTIFY(0x0001)
+#define OTA_M_ID_OTA_AVAILABLE_NOTIFY AM_MESSAGE_ID_SPECIFIC_NOTIFY(0x0001)
 
 static struct am_actor am_actor_ota0;
 struct am_api_functions *am = nullptr;
@@ -731,7 +731,6 @@ bool StdOtauPlugin::checkForUpdateImageImage(OtauNode *node)
         {
             node->setHasData(true);
             DBG_Printf(DBG_OTA, "OTAU: found update file %s\n", qPrintable(updateFile));
-            return true;
         }
         else
         {
@@ -740,7 +739,42 @@ bool StdOtauPlugin::checkForUpdateImageImage(OtauNode *node)
         }
     }
 
-    return false;
+#ifdef USE_ACTOR_MODEL
+    if (am)
+    {
+        // broadcast OTA0 OTA_M_ID_OTA_AVAILABLE_NOTIFY message
+        struct am_message *m;
+
+        m = am->msg_alloc();
+        if (m)
+        {
+            m->src = AM_ACTOR_ID_OTA;
+            m->dst = AM_ACTOR_ID_SUBSCRIBERS;
+            m->id = OTA_M_ID_OTA_AVAILABLE_NOTIFY;
+
+            am->msg_put_u64(m, (am_u64)(node->address().ext()));
+            am->msg_put_u16(m, node->manufacturerId);
+            am->msg_put_u16(m, node->imageType());
+            am->msg_put_u32(m, node->softwareVersion());
+            am->msg_put_u16(m, (unsigned short)node->hardwareVersion());
+            am->msg_put_u8(m, node->permitUpdate());
+
+            if (node->hasData())
+            {
+                am->msg_put_u16(m, 1); // count
+                am->msg_put_u32(m, node->file.fileVersion);
+            }
+            else
+            {
+                am->msg_put_u16(m, 0); // count
+            }
+
+            am->send_message(m);
+        }
+    }
+#endif // USE_ACTOR_MODEL
+
+    return node->hasData();
 }
 
 /*! Invalidates the upgrade end request.
@@ -1767,41 +1801,6 @@ void StdOtauPlugin::queryNextImageRequest(const deCONZ::ApsDataIndication &ind, 
             }
         }
     }
-
-#ifdef USE_ACTOR_MODEL
-    if (am)
-    {
-        // broadcast OTA0 QUERY_NEXT_IMAGE_NOTIFY message
-        struct am_message *m;
-
-        m = am->msg_alloc();
-        m->src = AM_ACTOR_ID_OTA;
-        m->dst = AM_ACTOR_ID_SUBSCRIBERS;
-        m->id = OTA_M_ID_QUERY_NEXT_IMAGE_NOTIFY;
-
-        am->msg_put_u64(m, (am_u64)(node->address().ext()));
-        am->msg_put_u16(m, node->manufacturerId);
-        am->msg_put_u16(m, node->imageType());
-        am->msg_put_u32(m, node->softwareVersion());
-        am->msg_put_u16(m, (unsigned short)node->hardwareVersion());
-
-        if (node->hasData())
-        {
-            am->msg_put_u32(m, node->file.fileVersion);
-        }
-        else
-        {
-            am->msg_put_u32(m, 0);
-        }
-
-        am->send_message(m);
-    }
-#endif // USE_ACTOR_MODEL
-
-    // if (node->hasData() && node->rxOnWhenIdle)
-    // { // sleeping devices must be manually enabled
-    //     node->setPermitUpdate(true);
-    // }
 
     if (queryNextImageResponse(node))
     {

--- a/std_otau_plugin.cpp
+++ b/std_otau_plugin.cpp
@@ -569,6 +569,7 @@ void StdOtauPlugin::nodeSelected(const deCONZ::Node *node)
     OtauNode *otauNode = m_model->getNode(node->address());
     if (otauNode != nullptr)
     {
+        m_selectedNodeAddress = node->address();
         m_w->displayNode(otauNode, m_model->index(otauNode->row, 0));
     }
     else
@@ -901,13 +902,15 @@ void StdOtauPlugin::downloadTimerFired()
         {
             QFile::remove(m_downloadIndexPath);
         }
-        m_downloadHandle = N_Download(qPrintable(m_downloadIndexUrl), 1 << 21, downloadIndexCallback, this);
+        unsigned maxFileSize = 1 << 21; // 2 MB, should be plenty enough
+        m_downloadHandle = N_Download(qPrintable(m_downloadIndexUrl), maxFileSize, downloadIndexCallback, this);
         m_downloadState = DownloadStateLoadIndex;
         m_downloadTimer->start(20000);
     }
     else if (m_downloadState == DownloadStateLoadIndex)
     {
-        DBG_Printf(DBG_INFO, "OTAU: failed to download OTA index\n");
+        DBG_Printf(DBG_ERROR, "OTAU: failed to download OTA index\n");
+        m_downloadState = DownloadStateInitial;
     }
     else if (m_downloadState == DownloadStateIdle)
     {
@@ -919,6 +922,8 @@ void StdOtauPlugin::downloadTimerFired()
         };
 
         std::vector<KOP> known;
+
+        m_downloadState = DownloadStateInitial;
 
         {
             auto i = m_model->nodes().cbegin();
@@ -1062,7 +1067,12 @@ void StdOtauPlugin::downloadTimerFired()
 
 void StdOtauPlugin::onDownloadedIndex(const uint8_t *data, unsigned int size)
 {
-    if (data && 512 < size && m_downloadState == DownloadStateLoadIndex)
+    bool ok = false;
+
+    if (m_downloadState != DownloadStateLoadIndex)
+        return; // should not happen
+
+    if (data && 512 < size)
     {
         DBG_Printf(DBG_OTA, "OTAU: downloaded index file: %u kB\n", size / 1000);
         QFile f(m_downloadIndexPath);
@@ -1070,12 +1080,17 @@ void StdOtauPlugin::onDownloadedIndex(const uint8_t *data, unsigned int size)
         {
             f.write((const char*)data, size);
             f.close();
-        }
+            ok = true;
+            broadcastImageNotify();
+            m_downloadTimer->stop();
+            m_downloadState = DownloadStateIdle;
+            m_downloadTimer->start(50);
+        }        
+    }
 
-        broadcastImageNotify();
-        m_downloadTimer->stop();
-        m_downloadState = DownloadStateIdle;
-        m_downloadTimer->start(5000);
+    if (!ok)
+    {
+        m_downloadState = DownloadStateInitial;
     }
 }
 
@@ -1236,71 +1251,87 @@ void StdOtauPlugin::checkFileLinks()
     }
 }
 
+/*! Executed when check online button is clicked */
+void StdOtauPlugin::downloadOtaFiles()
+{
+    if (m_downloadState == DownloadStateInitial)
+    {
+        m_downloadsEnabled = true;
+        m_downloadTimer->start(10);
+
+        if (m_selectedNodeAddress.hasExt())
+        {
+            unicastImageNotify(m_selectedNodeAddress);
+        }
+        else
+        {
+            broadcastImageNotify();
+        }
+    }
+}
+
 /*! Sends a image notify request.
     \param notf - the request parameters
     \return true on success false otherwise
  */
 bool StdOtauPlugin::imageNotify(ImageNotifyReq *notf)
 {
-    if (m_state == StateEnabled)
+    deCONZ::ApsDataRequest req;
+    deCONZ::ZclFrame zclFrame;
+
+    OtauNode *node = nullptr;
+
+    if (notf->addrMode == deCONZ::ApsExtAddress)
+        node = m_model->getNode(notf->addr);
+
+    req.setDstAddressMode(notf->addrMode);
+    req.dstAddress() = notf->addr;
+    req.setDstEndpoint(notf->dstEndpoint);
+    req.setSrcEndpoint(m_srcEndpoint);
+    if (node)
     {
-        deCONZ::ApsDataRequest req;
-        deCONZ::ZclFrame zclFrame;
+        req.setTxOptions(deCONZ::ApsTxAcknowledgedTransmission);
+        req.setProfileId(node->profileId);
+        DBG_Printf(DBG_OTA, "OTAU: send img notify to " FMT_MAC "\n", FMT_MAC_CAST(node->address().ext()));
+    }
+    else
+    {
+        req.setProfileId(0x0104);
+    }
+    req.setClusterId(OTAU_CLUSTER_ID);
 
-        OtauNode *node = nullptr;
+    req.setRadius(notf->radius);
 
-        if (notf->addrMode == deCONZ::ApsExtAddress)
-            node = m_model->getNode(notf->addr);
+    zclFrame.setSequenceNumber(m_zclSeq++);
+    zclFrame.setCommandId(OTAU_IMAGE_NOTIFY_CMD_ID);
 
-        req.setDstAddressMode(notf->addrMode);
-        req.dstAddress() = notf->addr;
-        req.setDstEndpoint(notf->dstEndpoint);
-        req.setSrcEndpoint(m_srcEndpoint);
-        if (node)
-        {
-            req.setTxOptions(deCONZ::ApsTxAcknowledgedTransmission);
-            req.setProfileId(node->profileId);
-            DBG_Printf(DBG_OTA, "OTAU: send img notify to " FMT_MAC "\n", FMT_MAC_CAST(node->address().ext()));
-        }
-        else
-        {
-            req.setProfileId(0x0104);
-        }
-        req.setClusterId(OTAU_CLUSTER_ID);
+    uint8_t frameControl = deCONZ::ZclFCClusterCommand |
+            deCONZ::ZclFCDirectionServerToClient;
 
-        req.setRadius(notf->radius);
+    if (notf->addr.isNwkBroadcast())
+    {
+        frameControl |= deCONZ::ZclFCDisableDefaultResponse;
+    }
 
-        zclFrame.setSequenceNumber(m_zclSeq++);
-        zclFrame.setCommandId(OTAU_IMAGE_NOTIFY_CMD_ID);
+    zclFrame.setFrameControl(frameControl);
 
-        uint8_t frameControl = deCONZ::ZclFCClusterCommand |
-                deCONZ::ZclFCDirectionServerToClient;
+    { // ZCL payload
+        QDataStream stream(&zclFrame.payload(), QIODevice::WriteOnly);
+        stream.setByteOrder(QDataStream::LittleEndian);
 
-        if (notf->addr.isNwkBroadcast())
-        {
-            frameControl |= deCONZ::ZclFCDisableDefaultResponse;
-        }
+        stream << static_cast<quint8>(0x00); // query jitter
+        stream << static_cast<quint8>(100); // query jitter value
+    }
 
-        zclFrame.setFrameControl(frameControl);
+    { // ZCL frame
+        QDataStream stream(&req.asdu(), QIODevice::WriteOnly);
+        stream.setByteOrder(QDataStream::LittleEndian);
+        zclFrame.writeToStream(stream);
+    }
 
-        { // ZCL payload
-            QDataStream stream(&zclFrame.payload(), QIODevice::WriteOnly);
-            stream.setByteOrder(QDataStream::LittleEndian);
-
-            stream << static_cast<quint8>(0x00); // query jitter
-            stream << static_cast<quint8>(100); // query jitter value
-        }
-
-        { // ZCL frame
-            QDataStream stream(&req.asdu(), QIODevice::WriteOnly);
-            stream.setByteOrder(QDataStream::LittleEndian);
-            zclFrame.writeToStream(stream);
-        }
-
-        if (deCONZ::ApsController::instance()->apsdeDataRequest(req) == deCONZ::Success)
-        {
-            return true;
-        }
+    if (deCONZ::ApsController::instance()->apsdeDataRequest(req) == deCONZ::Success)
+    {
+        return true;
     }
 
     return false;
@@ -2351,6 +2382,8 @@ QWidget *StdOtauPlugin::createWidget()
     if (!m_w)
     {
         m_w = new StdOtauWidget(nullptr);
+
+        connect(m_w, &StdOtauWidget::checkOnlineOtaFiles, this, &StdOtauPlugin::downloadOtaFiles);
 
         connect(m_w, SIGNAL(unicastImageNotify(deCONZ::Address)),
                 this, SLOT(unicastImageNotify(deCONZ::Address)));

--- a/std_otau_plugin.cpp
+++ b/std_otau_plugin.cpp
@@ -213,6 +213,84 @@ int am_plugin_init(struct am_api_functions *api)
 
 #endif // USE_ACTOR_MODEL
 
+static bool jsonGetLong(U_SStream obj, const char *key, long *value)
+{
+    if (0 == U_sstream_find(&obj, key) || 0 == U_sstream_find(&obj, ":"))
+        return false;
+
+    U_sstream_seek(&obj, obj.pos + 1);
+    *value = U_sstream_get_long(&obj);
+    return true;
+}
+
+static bool jsonGetU32(U_SStream obj, const char *key, uint32_t *value)
+{
+    long tmp;
+
+    if (jsonGetLong(obj, key, &tmp))
+    {
+        *value = tmp;
+        return true;
+    }
+
+    return false;
+}
+
+static bool jsonGetString(U_SStream skv, const char *key, char *str, unsigned maxlen)
+{
+    char keyQuoted[128];
+    unsigned keyLength = U_strlen(key);
+    Q_ASSERT(keyLength < sizeof(keyQuoted));
+    keyQuoted[0] = '"';
+    U_memcpy(&keyQuoted[1], key, keyLength);
+    keyQuoted[keyLength + 1] = '"';
+    keyQuoted[keyLength + 2] = '\0';
+
+    *str = '\0';
+    if (0 == U_sstream_find(&skv, keyQuoted) || 0 == U_sstream_find(&skv, ":") || 0 == U_sstream_find(&skv, "\""))
+        return false;
+
+    U_sstream_seek(&skv, skv.pos + 1);
+    U_sstream_skip_whitespace(&skv);
+
+    unsigned pos = skv.pos;
+    if (0 == U_sstream_find(&skv, "\""))
+        return false;
+
+    skv.len = skv.pos;
+    skv.pos = pos;
+
+    unsigned len = skv.len - skv.pos;
+    if (len >= maxlen)
+        return false;
+
+    U_memcpy(str, &skv.str[skv.pos], len);
+    str[len] = '\0';
+    return true;
+}
+
+static void U_sstream_put_hex_u16(U_SStream *ss, uint16_t value)
+{
+    const uint8_t b[2] = {
+        (uint8_t)((value >> 8) & 0xFF),
+        (uint8_t)(value & 0xff)
+    };
+
+    U_sstream_put_hex(ss, &b, 2);
+}
+
+static void U_sstream_put_hex_u32(U_SStream *ss, uint32_t value)
+{
+    const uint8_t b[4] = {
+        (uint8_t)((value >> 24) & 0xFF),
+        (uint8_t)((value >> 16) & 0xFF),
+        (uint8_t)((value >> 8) & 0xFF),
+        (uint8_t)(value & 0xff)
+    };
+
+    U_sstream_put_hex(ss, &b, 4);
+}
+
 /*! The constructor.
  */
 StdOtauPlugin::StdOtauPlugin(QObject *parent) :
@@ -250,19 +328,26 @@ StdOtauPlugin::StdOtauPlugin(QObject *parent) :
     connect(m_downloadTimer, SIGNAL(timeout()),
             this, SLOT(downloadTimerFired()));
 
-    //QString defaultImgPath = deCONZ::getStorageLocation(deCONZ::ApplicationsDataLocation) + "/otau";
     QString defaultImgPath = deCONZ::getStorageLocation(deCONZ::HomeLocation) + "/otau";
     m_imgPath = deCONZ::appArgumentString("--otau-img-path", defaultImgPath);
 
     QDir otauDir(m_imgPath);
 
+    if (!otauDir.exists())
+    {
+        QString secondaryPath = deCONZ::getStorageLocation(deCONZ::ApplicationsDataLocation) + "/otau";
+
+        otauDir = secondaryPath;
+        if (!otauDir.exists())
+            otauDir.mkdir(secondaryPath);
+
+        if (otauDir.exists())
+            m_imgPath = secondaryPath;
+    }
+
     if (otauDir.exists())
     {
         DBG_Printf(DBG_OTA, "OTAU: image path: %s\n", qPrintable(m_imgPath));
-    }
-    else
-    {
-        DBG_Printf(DBG_ERROR, "OTAU: image path does not exist: %s\n", qPrintable(m_imgPath));
     }
 
     deCONZ::ApsController *apsCtrl = deCONZ::ApsController::instance();
@@ -303,32 +388,13 @@ StdOtauPlugin::StdOtauPlugin(QObject *parent) :
 
     // Koenkk/zigbee-OTA repository is a well maintained source for OTA image files.
     // The index.json contains links to the files which are also mirrored on Github.
-    /*
-      [{
-        "fileName": "1135-0100-1000002A-Kobold.zigbee",
-        "fileVersion": 268435498,
-        "fileSize": 244094,
-        "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/DresdenElektronik/1135-0100-1000002A-Kobold.zigbee",
-        "imageType": 256,
-        "manufacturerCode": 4405,
-        "sha512": "0905f0e6a469be3893f2c665156f18077258e24439e283c9f4b121553a94e8eb142e6250e721585ddd9aceef75da3c10a03defaee89885d7cb8f08449a20912d",
-        "otaHeaderString": "",
-        "originalUrl": "https://deconz.dresden-elektronik.de/otau/1135-0100-1000002A-Kobold.zigbee"
-      }, {...}]
-
-    */
     m_downloadIndexUrl = "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/refs/heads/master/index.json";
     if (config.contains("otau/online-url"))
     {
         m_downloadIndexUrl = config.value("otau/online-url", m_downloadIndexUrl).toString();
     }
 
-    if (m_downloadsEnabled)
-    {
-        m_downloadTimer->start(2000);
-    }
-
-    checkFileLinks();
+    createLocalFileIndex();
 }
 
 /*! APSDE-DATA.indication callback.
@@ -579,15 +645,11 @@ void StdOtauPlugin::nodeSelected(const deCONZ::Node *node)
 }
 
 /*! Checks if a new otau image for the node is available in the otau folder.
-    Otau images must be in the <otau> directory and must have a proper formatted filename.
-    All numbers are hexaecimal and in capital letters.
-    filename: <manufacturer code>-<imagetype>-<fileversion>-someArbitraryText.zigbee
-    example: 113D-AB12-1F010400-FLS-RGB.zigbee
+    Otau images must be in the <otau> directory.
 
     \param node - the node for which the check will be done
-    \param path - the path to look for .zigbee files
  */
-bool StdOtauPlugin::checkForUpdateImageImage(OtauNode *node, const QString &path)
+bool StdOtauPlugin::checkForUpdateImageImage(OtauNode *node)
 {
     deCONZ::ApsController *apsCtrl = deCONZ::ApsController::instance();
     if (!apsCtrl)
@@ -595,127 +657,81 @@ bool StdOtauPlugin::checkForUpdateImageImage(OtauNode *node, const QString &path
         return false;
     }
 
-    if (apsCtrl->getParameter(deCONZ::ParamOtauActive) == 0)
-    {
-        return false;
-    }
+    // if (apsCtrl->getParameter(deCONZ::ParamOtauActive) == 0)
+    // {
+    //     return false;
+    // }
 
+    QString updateFile;
     uint32_t cmpFileVersion = node->softwareVersion();
 
-    const QString otaIndexPath = deCONZ::getStorageLocation(deCONZ::ApplicationsDataLocation) + "/ota_index.txt";
-
-    if (!QFile::exists(otaIndexPath))
+    if (!QFile::exists(m_localIndexPath))
         return false;
 
     {
-        QFile f(otaIndexPath);
+        QFile f(m_localIndexPath);
         if (!f.open(QFile::ReadOnly))
             return false;
 
-            for (;;)
+        for (;;)
+        {
+            QByteArray line = f.readLine().trimmed(); // one json object per line
+            if (line.size() <= 0)
+                break;
+
+            U_SStream ss;
+            U_sstream_init(&ss, line.data(), line.size());
+
+            if (U_sstream_peek_char(&ss) != '{')
+                continue;
+
+            uint32_t mfcode;
+            if (!jsonGetU32(ss, "manufacturerCode", &mfcode))
+                continue;
+
+            if (mfcode != node->manufacturerId)
+                continue;
+
+            uint32_t imageType;
+            if (!jsonGetU32(ss, "imageType", &imageType))
+                continue;
+
+            if (imageType != node->imageType())
+                continue;
+
+            uint32_t fileVersion;
+            if (!jsonGetU32(ss, "fileVersion", &fileVersion))
+                continue;
+
+            if (fileVersion <= cmpFileVersion)
+                continue;
+
             {
-                QByteArray line = f.readLine().trimmed();
-                if (line.size() <= 0)
+                char path[2048];
+                if (!jsonGetString(ss, "path", path, sizeof(path)))
+                    continue;
+
+                updateFile = path;
+                if (QFile::exists(updateFile))
                     break;
 
-                U_SStream ss;
-                U_sstream_init(&ss, line.data(), line.size());
-
-                long mfcode = U_sstream_get_long(&ss);
-
-                if (mfcode != node->manufacturerId)
-                    continue;
-
-                long imageType = U_sstream_get_long(&ss);
-                if (imageType != node->imageType())
-                    continue;
-
-                long version = U_sstream_get_long(&ss);
-
-                if (ss.status != U_SSTREAM_OK)
-                    continue;
-
-
-
+                updateFile = {};
             }
-    }
 
-    bool ok;
-
-    uint32_t fileVersion;
-    uint16_t imageType;
-    uint16_t manufacturerId;
-    QString updateFile = "";
-    QDir dir(path);
-
-    if (!dir.exists())
-    {
-        DBG_Printf(DBG_OTA, "OTAU: image path does not exist: %s\n", qPrintable(path));
-        return false;
-    }
-
-    QStringList ls = dir.entryList();
-
-    auto i = ls.begin();
-    auto end = ls.end();
-
-    for (; i != end; ++i)
-    {
-        if (!i->endsWith(".zigbee"))
-        {
-            continue;
-        }
-
-        QString plain = *i;
-        plain.replace(".zigbee", "");
-
-        QStringList args = plain.split('-');
-
-        if (args.size() >= 3)
-        {
-            manufacturerId = args[0].toUShort(&ok, 16);
-
-            if (!ok || manufacturerId != node->manufacturerId)
-            {
+            if (ss.status != U_SSTREAM_OK)
                 continue;
-            }
-
-            imageType = args[1].toUShort(&ok, 16);
-
-            if (!ok)
-            {
-                continue;
-            }
-
-            if (imageType == node->imageType())
-            {
-                fileVersion = args[2].toUInt(&ok, 16);
-
-                if (!ok)
-                {
-                    continue;
-                }
-
-                if (fileVersion > cmpFileVersion)
-                {
-                    updateFile = *i;
-                    cmpFileVersion = fileVersion;
-                    DBG_Printf(DBG_OTA, "OTAU: Match otau version 0x%08X image type 0x%04X\n", fileVersion, imageType);
-                }
-            }
-
         }
     }
 
     if (!updateFile.isEmpty())
     {
-        updateFile.prepend(path + "/");
         OtauFileLoader ld;
 
         if (ld.readFile(updateFile, node->file))
         {
             node->setHasData(true);
             DBG_Printf(DBG_OTA, "OTAU: found update file %s\n", qPrintable(updateFile));
+            return true;
         }
         else
         {
@@ -874,45 +890,80 @@ void StdOtauPlugin::activityTimerFired()
     }
 }
 
+void StdOtauPlugin::downloadCancelOrError()
+{
+    m_downloadState = DownloadStateInitial;
+}
+
 static void downloadIndexCallback(N_DownloadData *dd)
 {
     StdOtauPlugin *q = static_cast<StdOtauPlugin*>(dd->user);
     if (dd->status == N_DownloadDone)
     {
-        q->onDownloadedIndex(dd->data, dd->data_size);
+        q->downloadedStoreIndex(dd->data, dd->data_size);
     }
     else
     {
-        DBG_Printf(DBG_ERROR, "OTAU: error downloading index file (%d)\n", (int)dd->status);
+        DBG_Printf(DBG_ERROR, "OTAU: error downloading index file. status: %d\n", (int)dd->status);
+        q->downloadCancelOrError();
+    }
+}
+
+static void downloadOtaFileCallback(N_DownloadData *dd)
+{
+    StdOtauPlugin *q = static_cast<StdOtauPlugin*>(dd->user);
+    if (dd->status == N_DownloadDone)
+    {
+        q->downloadedStoreOtaFile(dd->data, dd->data_size);
+    }
+    else
+    {
+        DBG_Printf(DBG_ERROR, "OTAU: error downloading index file. status: %d\n", (int)dd->status);
+        // let run into timeout and proceed
     }
 }
 
 void StdOtauPlugin::downloadTimerFired()
 {
-    if (m_downloadState == DownloadStateInitial)
+    if (m_downloadState == DownloadStateRequestIndex)
     {
         if (!m_downloadsEnabled)
+        {
+            downloadCancelOrError();
             return;
+        }
 
         if (m_downloadIndexUrl.size() == 0)
+        {
+            downloadCancelOrError();
             return;
+        }
 
         m_downloadIndexPath = deCONZ::getStorageLocation(deCONZ::ApplicationsDataLocation) + "/ota_remote_index.json";
-        if (QFile::exists(m_downloadIndexPath))
+
+        auto now = deCONZ::steadyTimeRef();
+        bool indexExists = QFile::exists(m_downloadIndexPath);
+        bool needRefresh = (!indexExists || !isValid(m_downloadIndexAge) || deCONZ::TimeSeconds{30 * 60} < (now - m_downloadIndexAge));
+
+        if (needRefresh)
         {
-            QFile::remove(m_downloadIndexPath);
+            unsigned maxFileSize = 1 << 21; // 2 MB, should be plenty enough
+            m_downloadHandle = N_Download(qPrintable(m_downloadIndexUrl), maxFileSize, downloadIndexCallback, this);
+            m_downloadState = DownloadStateWaitIndexResponse;
+            m_downloadTimer->start(20000);
         }
-        unsigned maxFileSize = 1 << 21; // 2 MB, should be plenty enough
-        m_downloadHandle = N_Download(qPrintable(m_downloadIndexUrl), maxFileSize, downloadIndexCallback, this);
-        m_downloadState = DownloadStateLoadIndex;
-        m_downloadTimer->start(20000);
+        else
+        {
+            m_downloadState = DownloadStateProcessIndex;
+            m_downloadTimer->start(50);
+        }
     }
-    else if (m_downloadState == DownloadStateLoadIndex)
+    else if (m_downloadState == DownloadStateWaitIndexResponse)
     {
         DBG_Printf(DBG_ERROR, "OTAU: failed to download OTA index\n");
-        m_downloadState = DownloadStateInitial;
+        downloadCancelOrError();
     }
-    else if (m_downloadState == DownloadStateIdle)
+    else if (m_downloadState == DownloadStateProcessIndex)
     {
         struct KOP
         {
@@ -929,9 +980,11 @@ void StdOtauPlugin::downloadTimerFired()
             auto i = m_model->nodes().cbegin();
             const auto iend = m_model->nodes().cend();
 
-
             for (; i != iend; ++i)
             {
+                if ((*i)->manufacturerId == 0)
+                    continue;
+
                 auto j = known.cbegin();
                 const auto jend = known.cend();
 
@@ -957,7 +1010,7 @@ void StdOtauPlugin::downloadTimerFired()
 
         if (known.empty())
         {
-            // TODO check later?
+            downloadCancelOrError();
             return;
         }
 
@@ -977,11 +1030,25 @@ void StdOtauPlugin::downloadTimerFired()
         U_SStream ss;
         U_sstream_init(&ss, data.data(), data.size());
 
+        /*
+      [{
+        "fileName": "1135-0100-1000002A-Kobold.zigbee",
+        "fileVersion": 268435498,
+        "fileSize": 244094,
+        "url": "https://raw.githubusercontent.com/Koenkk/zigbee-OTA/master/images/DresdenElektronik/1135-0100-1000002A-Kobold.zigbee",
+        "imageType": 256,
+        "manufacturerCode": 4405,
+        "sha512": "0905f0e6a469be3893f2c665156f18077258e24439e283c9f4b121553a94e8eb142e6250e721585ddd9aceef75da3c10a03defaee89885d7cb8f08449a20912d",
+        "otaHeaderString": "",
+        "originalUrl": "https://deconz.dresden-elektronik.de/otau/1135-0100-1000002A-Kobold.zigbee"
+      }, {...}]
+        */
+
         for (;U_sstream_find(&ss, "{");)
         {
-            unsigned manufacturerCode;
-            unsigned imageType;
-            unsigned fileVersion;
+            uint32_t manufacturerCode;
+            uint32_t imageType;
+            uint32_t fileVersion;
 
             U_SStream so = ss; // stream limited to one object
             if (U_sstream_find(&so, "}"))
@@ -996,33 +1063,14 @@ void StdOtauPlugin::downloadTimerFired()
                 break; // invalid json
             }
 
-            U_SStream skv; // stream to extract values
-
-            skv = so;
-            if (0 == U_sstream_find(&skv, "manufacturerCode") || 0 == U_sstream_find(&skv, ":"))
+            if (!jsonGetU32(so, "manufacturerCode", &manufacturerCode))
                 continue;
-            U_sstream_seek(&skv, skv.pos + 1);
-            manufacturerCode = U_sstream_get_long(&skv);
 
-            skv = so;
-            if (0 == U_sstream_find(&skv, "imageType") || 0 == U_sstream_find(&skv, ":"))
+            if (!jsonGetU32(so, "imageType", &imageType))
                 continue;
-            U_sstream_seek(&skv, skv.pos + 1);
-            imageType = U_sstream_get_long(&skv);
 
-            skv = so;
-            if (0 == U_sstream_find(&skv, "fileVersion") || 0 == U_sstream_find(&skv, ":"))
+            if (!jsonGetU32(so, "fileVersion", &fileVersion))
                 continue;
-            U_sstream_seek(&skv, skv.pos + 1);
-            fileVersion = U_sstream_get_long(&skv);
-
-            struct DownloadOtaFile
-            {
-                uint16_t manufacturerCode;
-                uint16_t imageType;
-                uint32_t fileVersion;
-                char url[512];
-            };
 
             auto j = known.cbegin();
             const auto jend = known.cend();
@@ -1032,66 +1080,188 @@ void StdOtauPlugin::downloadTimerFired()
                 if (j->manufacturerCode == manufacturerCode && j->imageType == imageType)
                 {
                     DownloadOtaFile dlota;
+                    char valbuf[1280];
 
                     dlota.manufacturerCode = manufacturerCode;
                     dlota.imageType = imageType;
 
-                    // URL
-                    skv = so;
-                    if (0 == U_sstream_find(&skv, "\"url\"") || 0 == U_sstream_find(&skv, ":") || 0 == U_sstream_find(&skv, "\""))
+                    if (!jsonGetString(so, "url", valbuf, sizeof(valbuf)))
                         continue;
-                    U_sstream_seek(&skv, skv.pos + 1);
-                    U_sstream_skip_whitespace(&skv);
 
-                    unsigned pos = skv.pos;
-                    if (0 == U_sstream_find(&skv, "\""))
-                        break;
+                    dlota.url = valbuf;
 
-                    skv.len = skv.pos;
-                    skv.pos = pos;
+                    if (!jsonGetString(so, "sha512", valbuf, sizeof(valbuf)))
+                        continue;
 
-                    unsigned len = skv.len - skv.pos;
-                    if (len >= sizeof(dlota.url))
-                        break;
+                    if (U_strlen(valbuf) != 128)
+                        continue;
 
-                    U_memcpy(dlota.url, &skv.str[skv.pos], len);
-                    dlota.url[len] = '\0';
+                    dlota.sha512 = valbuf;
 
-                    DBG_Printf(DBG_OTA, "OTAU: download %04X-%04X-%08X from %s\n", manufacturerCode, imageType, fileVersion, dlota.url);
+                    { // check if we already have this file
+                        bool found = false;
+                        QFile f(m_localIndexPath);
+                        auto needle = QByteArray::fromRawData(valbuf, 128); // sha512
+
+                        if (f.open(QFile::ReadOnly))
+                        {
+                            for (;;)
+                            {
+                                QByteArray line = f.readLine().trimmed(); // one json object per line
+                                if (line.size() <= 0)
+                                    break;
+
+                                if (line.contains(needle))
+                                {
+                                    found = true;
+                                    break;
+                                }
+                            }
+                        }
+
+                        if (found) // don't need to download twice
+                            break;
+                    }
+
+                    U_SStream fname;
+                    U_sstream_init(&fname, valbuf, sizeof(valbuf));
+
+                    U_sstream_put_hex_u16(&fname, manufacturerCode);
+                    U_sstream_put_str(&fname, "-");
+                    U_sstream_put_hex_u16(&fname, imageType);
+                    U_sstream_put_str(&fname, "-");
+                    U_sstream_put_hex_u32(&fname, fileVersion);
+                    U_sstream_put_str(&fname, "-");
+                    for (int v = 0; v < 6; v++)
+                        fname.str[fname.pos++] = dlota.sha512.c_str()[v];
+
+                    fname.str[fname.pos] = '\0';
+                    U_sstream_put_str(&fname, ".zigbee");
+                    dlota.fileName = fname.str;
+
+                    bool found = false;
+                    for (const auto &dl : m_downloads)
+                    {
+                        if (dl.sha512 == dlota.sha512)
+                        {
+                            found = true;
+                            break;
+                        }
+                    }
+
+                    if (!found)
+                    {
+                        m_downloads.push_back(dlota);
+                        DBG_Printf(DBG_OTA, "OTAU: download %s from %s\n", dlota.fileName.c_str(), dlota.url.c_str());
+                    }
                     break;
                 }
             }
         }
+
+        if (!m_downloads.empty())
+        {
+            m_downloadState = DownloadStateRequestOtaFile;
+            m_downloadTimer->start(50);
+        }
+    }
+    else if (m_downloadState == DownloadStateRequestOtaFile)
+    {
+        if (m_downloads.empty())
+        {
+            downloadCancelOrError();
+            return;
+        }
+        DownloadOtaFile &dl = m_downloads.front();
+        if (dl.retry < 2)
+        {
+            unsigned maxFileSize = 1 << 21; // 2 MB, should be plenty enough
+            dl.retry++;
+            m_downloadHandle = N_Download(dl.url.c_str(), maxFileSize, downloadOtaFileCallback, this);
+            m_downloadState = DownloadStateWaitOtaFileResponse;
+            m_downloadTimer->start(20000);
+        }
+        else
+        {
+            m_downloads.front() = m_downloads.back();
+            m_downloads.pop_back();
+            m_downloadTimer->start(100);
+        }
+    }
+    else if (m_downloadState == DownloadStateWaitOtaFileResponse)
+    {
+        m_downloadState = DownloadStateRequestOtaFile;
+        m_downloadTimer->start(100);
     }
 }
 
-void StdOtauPlugin::onDownloadedIndex(const uint8_t *data, unsigned int size)
+void StdOtauPlugin::downloadedStoreIndex(const uint8_t *data, unsigned int size)
 {
     bool ok = false;
 
-    if (m_downloadState != DownloadStateLoadIndex)
+    if (m_downloadState != DownloadStateWaitIndexResponse)
         return; // should not happen
 
     if (data && 512 < size)
     {
+        if (QFile::exists(m_downloadIndexPath))
+            QFile::remove(m_downloadIndexPath);
+
         DBG_Printf(DBG_OTA, "OTAU: downloaded index file: %u kB\n", size / 1000);
         QFile f(m_downloadIndexPath);
         if (f.open(QFile::ReadWrite))
         {
-            f.write((const char*)data, size);
+            auto n = f.write((const char*)data, size);
             f.close();
-            ok = true;
-            broadcastImageNotify();
-            m_downloadTimer->stop();
-            m_downloadState = DownloadStateIdle;
-            m_downloadTimer->start(50);
+
+            if (n == size)
+            {
+                ok = true;
+                m_downloadState = DownloadStateProcessIndex;
+                m_downloadTimer->start(50);
+            }
         }        
     }
 
     if (!ok)
     {
-        m_downloadState = DownloadStateInitial;
+        downloadCancelOrError();
     }
+}
+
+void StdOtauPlugin::downloadedStoreOtaFile(const uint8_t *data, unsigned int size)
+{
+    if (m_downloadState != DownloadStateWaitOtaFileResponse)
+        return; // should not happen
+
+    if (m_downloads.empty())
+        return; // should not happen
+
+    DownloadOtaFile dl = m_downloads.front();
+    m_downloads.front() = m_downloads.back();
+    m_downloads.pop_back();
+
+    QString filePath = m_imgPath + "/" + dl.fileName.c_str();
+
+    if (data && 512 < size)
+    {
+        if (QFile::exists(filePath))
+            QFile::remove(filePath);
+
+        DBG_Printf(DBG_OTA, "OTAU: downloaded %s: %u kB\n", dl.fileName.c_str(), size / 1000);
+        QFile f(filePath);
+        if (f.open(QFile::ReadWrite))
+        {
+            f.write((const char*)data, size);
+            f.close();
+        }
+    }
+
+    createLocalFileIndex();
+
+    // proceed with next (or finish)
+    m_downloadState = DownloadStateRequestOtaFile;
+    m_downloadTimer->start(50);
 }
 
 void StdOtauPlugin::markOtauActivity(const deCONZ::Address &address)
@@ -1134,22 +1304,33 @@ struct OtaIndexEntry
     uint32_t fileSize;
 };
 
-void StdOtauPlugin::checkFileLinks()
+void StdOtauPlugin::createLocalFileIndex()
 {
-    bool ok;
     QStringList paths;
-    paths.append(m_imgPath);
-    //paths.append(deCONZ::getStorageLocation(deCONZ::ApplicationsDataLocation) + "/otau");
 
-    QString otaIndexPath = deCONZ::getStorageLocation(deCONZ::ApplicationsDataLocation) + "/ota_index.txt";
-
-    if (QFile::exists(otaIndexPath))
     {
-        QFile::remove(otaIndexPath);
+        QString defaultImgPath = deCONZ::getStorageLocation(deCONZ::HomeLocation) + "/otau";
+        defaultImgPath = deCONZ::appArgumentString("--otau-img-path", defaultImgPath);
+
+        QDir otauDir(defaultImgPath);
+
+        if (otauDir.exists())
+            paths.append(defaultImgPath);
+
+        QString secondaryPath = deCONZ::getStorageLocation(deCONZ::ApplicationsDataLocation) + "/otau";
+        otauDir = secondaryPath;
+        if (otauDir.exists())
+            paths.append(secondaryPath);
+    }
+
+    m_localIndexPath = deCONZ::getStorageLocation(deCONZ::ApplicationsDataLocation) + "/ota_index.json";
+
+    if (QFile::exists(m_localIndexPath))
+    {
+        QFile::remove(m_localIndexPath);
     }
 
     std::vector<OtaIndexEntry> otaEntries;
-    OtaIndexEntry otaEntry;
 
     for (const QString &path : paths)
     {
@@ -1176,11 +1357,7 @@ void StdOtauPlugin::checkFileLinks()
             if (!of.fromArray(arr))
                 continue;
 
-            const QString fname = QString("%1-%2-%3").arg(of.manufacturerCode, 4, 16, QLatin1Char('0'))
-                                                     .arg(of.imageType, 4, 16, QLatin1Char('0'))
-                                                     .arg(of.fileVersion, 8, 16, QLatin1Char('0'))
-                                                     .toUpper();
-
+            OtaIndexEntry otaEntry;
             otaEntry.path = (path + "/" + n);
             otaEntry.mfcode = of.manufacturerCode;
             otaEntry.imagetype = of.imageType;
@@ -1189,41 +1366,25 @@ void StdOtauPlugin::checkFileLinks()
             U_memset(otaEntry.sha512, 0, sizeof(otaEntry.sha512));
             U_Sha512(arr.constData(), arr.size(), &otaEntry.sha512[0]);
 
-            ok = false;
+            bool found = false;
             for (const OtaIndexEntry &e : otaEntries)
             {
                 if (U_memcmp(e.sha512, otaEntry.sha512, sizeof(e.sha512)) == 0)
                 {
-                    ok = true;
+                    found = true;
                     break;
                 }
             }
 
-            if (!ok)
+            if (!found)
             {
                 otaEntries.push_back(otaEntry);
             }
-
-            ok = false;
-            for (const QString &n2 : ls)
-            {
-                if (n2.startsWith(fname))
-                {
-                    ok = true;
-                    break;
-                }
-            }
-
-            if (ok)
-                continue;
-
-            DBG_Printf(DBG_INFO, "OTAU: create %s.zigbee\n", qPrintable(fname));
-            file.copy(path + "/" + fname + ".zigbee");
         }
     }
 
     {
-        QFile otaIndexFile(otaIndexPath);
+        QFile otaIndexFile(m_localIndexPath);
         if (otaIndexFile.open(QFile::ReadWrite))
         {
             int count = 0;
@@ -1231,16 +1392,33 @@ void StdOtauPlugin::checkFileLinks()
             stream << "[\n";
             for (const OtaIndexEntry &e : otaEntries)
             {
+                char sha512Ascii[128 + 8];
+
+                {
+                    U_SStream ssha;
+                    U_sstream_init(&ssha, sha512Ascii, sizeof(sha512Ascii));
+                    U_sstream_put_hex(&ssha, e.sha512, 64);
+                    for (unsigned i = 0; i < ssha.pos; i++) // to lower
+                    {
+                        char ch = ssha.str[i];
+                        if (ch >= 'A' && ch <= 'Z')
+                            ch += (char)('a' - 'A');
+                        ssha.str[i] = ch;
+                    }
+                }
+
                 if (count)
                     stream << ",\n";
 
-                stream << "  {\n";
-                stream << "    \"fileVersion\": " << e.fileVersion << ",\n";
-                stream << "    \"fileSize\": " << e.fileSize << ",\n";
-                stream << "    \"manufacturerCode\": " << e.mfcode << ",\n";
-                stream << "    \"imageType\": " << e.imagetype << ",\n";
-                stream << "    \"url\": \"" << e.path << "\"\n";
-                stream << "  }";
+                // Important: one minified object per line (the parser expects exactly this)
+                stream << "{";
+                stream << "\"fileVersion\":" << e.fileVersion << ",";
+                stream << "\"fileSize\":" << e.fileSize << ",";
+                stream << "\"manufacturerCode\":" << e.mfcode << ",";
+                stream << "\"imageType\":" << e.imagetype << ",";
+                stream << "\"sha512\":\"" << sha512Ascii << "\",";
+                stream << "\"path\":\"" << e.path << "\"";
+                stream << "}";
                 count++;
             }
 
@@ -1252,10 +1430,11 @@ void StdOtauPlugin::checkFileLinks()
 }
 
 /*! Executed when check online button is clicked */
-void StdOtauPlugin::downloadOtaFiles()
+void StdOtauPlugin::downloadRequestIndex()
 {
     if (m_downloadState == DownloadStateInitial)
     {
+        m_downloadState = DownloadStateRequestIndex;
         m_downloadsEnabled = true;
         m_downloadTimer->start(10);
 
@@ -1548,7 +1727,7 @@ void StdOtauPlugin::queryNextImageRequest(const deCONZ::ApsDataIndication &ind, 
     node->setAddress(ind.srcAddress());
     node->refreshTimeout();
     node->restartElapsedTimer();
-    node->setStatus(OtauNode::StatusSuccess);
+    node->setStatus(OtauNode::StatusImageRequest);
 
     QDataStream stream(zclFrame.payload());
     stream.setByteOrder(QDataStream::LittleEndian);
@@ -1574,23 +1753,17 @@ void StdOtauPlugin::queryNextImageRequest(const deCONZ::ApsDataIndication &ind, 
     DBG_Printf(DBG_OTA, "OTAU: query next img req: " FMT_MAC " mfCode: 0x%04X, img type: 0x%04X, sw version: 0x%08X\n",
                FMT_MAC_CAST(ind.srcAddress().ext()), node->manufacturerId, node->imageType(), node->softwareVersion());
 
-    if (deCONZ::ApsController::instance()->getParameter(deCONZ::ParamOtauActive) != 0)
+    // if (deCONZ::ApsController::instance()->getParameter(deCONZ::ParamOtauActive) != 0)
     {
         // check for image
         if (!node->hasData() && m_otauTracker.size() < OTAU_MAX_ACTIVE)
         {
             node->file.subElements.clear();
             node->setHasData(false);
-            node->setPermitUpdate(false);
+            //node->setPermitUpdate(false);
 
-            if (!checkForUpdateImageImage(node, m_imgPath))
+            if (!checkForUpdateImageImage(node))
             {
-                QString secondaryPath = deCONZ::getStorageLocation(deCONZ::ApplicationsDataLocation) + "/otau";
-
-                if (!checkForUpdateImageImage(node, secondaryPath))
-                {
-
-                }
             }
         }
     }
@@ -1625,10 +1798,10 @@ void StdOtauPlugin::queryNextImageRequest(const deCONZ::ApsDataIndication &ind, 
     }
 #endif // USE_ACTOR_MODEL
 
-    if (node->hasData() && node->rxOnWhenIdle)
-    { // sleeping devices must be manually enabled
-        node->setPermitUpdate(true);
-    }
+    // if (node->hasData() && node->rxOnWhenIdle)
+    // { // sleeping devices must be manually enabled
+    //     node->setPermitUpdate(true);
+    // }
 
     if (queryNextImageResponse(node))
     {
@@ -1778,7 +1951,7 @@ void StdOtauPlugin::imageBlockRequest(const deCONZ::ApsDataIndication &ind, cons
         node->imgBlockReq.fileVersion = node->file.fileVersion;
     }
 
-    node->setStatus(OtauNode::StatusSuccess);
+    node->setStatus(OtauNode::StatusUploading);
     node->setOffset(node->imgBlockReq.offset);
     node->setImageType(node->imgBlockReq.imageType);
     node->notifyElapsedTimer();
@@ -2193,6 +2366,7 @@ void StdOtauPlugin::upgradeEndRequest(const deCONZ::ApsDataIndication &ind, cons
     DBG_Printf(DBG_OTA, "OTAU: upgrade end req: status: 0x%02X, fwVersion:0x%08X, imgType: 0x%04X\n", node->upgradeEndReq.status, node->upgradeEndReq.fileVersion, node->upgradeEndReq.imageType);
 
     node->setState(OtauNode::NodeIdle);
+    node->setStatus(OtauNode::StatusUpgradeEnd);
 
     if (node->upgradeEndReq.status == OTAU_SUCCESS)
     {
@@ -2205,7 +2379,6 @@ void StdOtauPlugin::upgradeEndRequest(const deCONZ::ApsDataIndication &ind, cons
             return;
         }
 
-        node->setStatus(OtauNode::StatusWaitUpgradeEnd);
         node->setOffset(node->file.totalImageSize); // mark done
 
         node->file.subElements.clear();
@@ -2293,10 +2466,6 @@ bool StdOtauPlugin::upgradeEndResponse(OtauNode *node, uint32_t upgradeTime)
     {
         node->apsRequestId = req.id();
         node->zclCommandId = zclFrame.commandId();
-        if (upgradeTime < OTA_TIME_INFINITE)
-        {
-            node->setStatus(OtauNode::StatusSuccess);
-        }
         ret = true;
     }
 
@@ -2383,7 +2552,7 @@ QWidget *StdOtauPlugin::createWidget()
     {
         m_w = new StdOtauWidget(nullptr);
 
-        connect(m_w, &StdOtauWidget::checkOnlineOtaFiles, this, &StdOtauPlugin::downloadOtaFiles);
+        connect(m_w, &StdOtauWidget::checkOnlineOtaFiles, this, &StdOtauPlugin::downloadRequestIndex);
 
         connect(m_w, SIGNAL(unicastImageNotify(deCONZ::Address)),
                 this, SLOT(unicastImageNotify(deCONZ::Address)));

--- a/std_otau_plugin.h
+++ b/std_otau_plugin.h
@@ -96,16 +96,18 @@ public Q_SLOTS:
     bool defaultResponse(OtauNode *node, quint8 commandId, quint8 status);
     void nodeEvent(const deCONZ::NodeEvent &event);
     void nodeSelected(const deCONZ::Node *node);
-    bool checkForUpdateImageImage(OtauNode *node, const QString &path);
+    bool checkForUpdateImageImage(OtauNode *node);
     void invalidateUpdateEndRequest(OtauNode *node);
     void imagePageTimerFired();
     void cleanupTimerFired();
     void activityTimerFired();
+    void downloadCancelOrError();
     void downloadTimerFired();
-    void onDownloadedIndex(const uint8_t *data, unsigned size);
+    void downloadRequestIndex();
+    void downloadedStoreIndex(const uint8_t *data, unsigned size);
+    void downloadedStoreOtaFile(const uint8_t *data, unsigned size);
     void markOtauActivity(const deCONZ::Address &address);
-    void checkFileLinks();
-    void downloadOtaFiles();
+    void createLocalFileIndex();
 
 Q_SIGNALS:
     void stateChanged(int state);
@@ -114,8 +116,22 @@ private:
     enum DownloadState
     {
         DownloadStateInitial,
-        DownloadStateLoadIndex,
-        DownloadStateIdle,
+        DownloadStateRequestIndex,
+        DownloadStateWaitIndexResponse,
+        DownloadStateProcessIndex,
+        DownloadStateRequestOtaFile,
+        DownloadStateWaitOtaFileResponse
+    };
+
+    struct DownloadOtaFile
+    {
+        int retry = 0;
+        uint16_t manufacturerCode;
+        uint16_t imageType;
+        uint32_t fileVersion;
+        std::string fileName;
+        std::string sha512;
+        std::string url;
     };
 
     void setState(State state);
@@ -125,6 +141,7 @@ private:
     QString m_downloadIndexUrl;
     deCONZ::Address m_delayedImageNotifyAddr;
     QString m_imgPath;
+    QString m_localIndexPath;
     OtauModel *m_model;
     State m_state;
     quint8 m_srcEndpoint;
@@ -136,9 +153,11 @@ private:
     QTimer *m_cleanupTimer;
     QTimer *m_activityTimer;
     QTimer *m_downloadTimer;
+    deCONZ::SteadyTimeRef m_downloadIndexAge = {};
     int m_downloadHandle = 0;
     QString m_downloadIndexPath;
     DownloadState m_downloadState = DownloadStateInitial;
+    std::vector<DownloadOtaFile> m_downloads;
     std::vector<OtauTracker> m_otauTracker;
     int m_fastPageSpaceing;
 };

--- a/std_otau_plugin.h
+++ b/std_otau_plugin.h
@@ -105,6 +105,7 @@ public Q_SLOTS:
     void onDownloadedIndex(const uint8_t *data, unsigned size);
     void markOtauActivity(const deCONZ::Address &address);
     void checkFileLinks();
+    void downloadOtaFiles();
 
 Q_SIGNALS:
     void stateChanged(int state);
@@ -120,6 +121,7 @@ private:
     void setState(State state);
     void checkIfNewOtauNode(const deCONZ::Node *node, uint8_t endpoint);
     bool m_downloadsEnabled = false;
+    deCONZ::Address m_selectedNodeAddress;
     QString m_downloadIndexUrl;
     deCONZ::Address m_delayedImageNotifyAddr;
     QString m_imgPath;

--- a/std_otau_plugin.h
+++ b/std_otau_plugin.h
@@ -101,6 +101,8 @@ public Q_SLOTS:
     void imagePageTimerFired();
     void cleanupTimerFired();
     void activityTimerFired();
+    void downloadTimerFired();
+    void onDownloadedIndex(const uint8_t *data, unsigned size);
     void markOtauActivity(const deCONZ::Address &address);
     void checkFileLinks();
 
@@ -108,8 +110,17 @@ Q_SIGNALS:
     void stateChanged(int state);
 
 private:
+    enum DownloadState
+    {
+        DownloadStateInitial,
+        DownloadStateLoadIndex,
+        DownloadStateIdle,
+    };
+
     void setState(State state);
     void checkIfNewOtauNode(const deCONZ::Node *node, uint8_t endpoint);
+    bool m_downloadsEnabled = false;
+    QString m_downloadIndexUrl;
     deCONZ::Address m_delayedImageNotifyAddr;
     QString m_imgPath;
     OtauModel *m_model;
@@ -122,6 +133,10 @@ private:
     QTimer *m_imagePageTimer;
     QTimer *m_cleanupTimer;
     QTimer *m_activityTimer;
+    QTimer *m_downloadTimer;
+    int m_downloadHandle = 0;
+    QString m_downloadIndexPath;
+    DownloadState m_downloadState = DownloadStateInitial;
     std::vector<OtauTracker> m_otauTracker;
     int m_fastPageSpaceing;
 };

--- a/std_otau_widget.cpp
+++ b/std_otau_widget.cpp
@@ -55,6 +55,10 @@ StdOtauWidget::StdOtauWidget(QWidget *parent) :
     // OTAU update tab
     m_ouNode = nullptr;
 
+    connect(ui->checkBoxAdvanced, &QCheckBox::clicked, this, &StdOtauWidget::advancedToggled);
+
+    connect(ui->ou_checkOnlineButton, &QPushButton::clicked, this, &StdOtauWidget::checkOnlineOtaFiles);
+
     connect(ui->ou_queryButton, SIGNAL(clicked()),
             this, SLOT(queryClicked()));
 
@@ -82,6 +86,7 @@ StdOtauWidget::StdOtauWidget(QWidget *parent) :
             this, SLOT(openClicked()));
 
     ui->tableView->setSortingEnabled(true);
+    ui->widgetAdvanced->setVisible(ui->checkBoxAdvanced->isChecked());
 
 #ifdef USE_ACTOR_MODEL
     if (am)
@@ -315,6 +320,11 @@ void StdOtauWidget::otauTableActivated(const QModelIndex &index)
     {
         emit activatedNodeAtRow(proxyModel->mapToSource(index).row());
     }
+}
+
+void StdOtauWidget::advancedToggled()
+{
+    ui->widgetAdvanced->setVisible(ui->checkBoxAdvanced->isChecked());
 }
 
 void StdOtauWidget::saveClicked()

--- a/std_otau_widget.h
+++ b/std_otau_widget.h
@@ -32,6 +32,7 @@ public Q_SLOTS:
     void clearSettingsBox();
     void updateSettingsBox();
     void otauTableActivated(const QModelIndex &index);
+    void advancedToggled();
 
     // OTAU upgrade
     void queryClicked();
@@ -57,6 +58,7 @@ Q_SIGNALS:
     void activatedNodeAtRow(int);
     void unicastImageNotify(deCONZ::Address);
     void unicastUpgradeEndRequest(deCONZ::Address);
+    void checkOnlineOtaFiles();
 
 private:
     void updateEditor();

--- a/std_otau_widget.ui
+++ b/std_otau_widget.ui
@@ -13,7 +13,7 @@
   <property name="windowTitle">
    <string>OTA Update</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QHBoxLayout" name="horizontalLayout_4">
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
@@ -21,18 +21,46 @@
      </property>
      <widget class="QWidget" name="tab">
       <attribute name="title">
-       <string>OTAU Update</string>
+       <string>Update</string>
       </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_2">
+      <layout class="QVBoxLayout" name="verticalLayout">
        <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_4"/>
+        <layout class="QHBoxLayout" name="horizontalLayout_5">
+         <item>
+          <widget class="QLabel" name="labelOtauState">
+           <property name="text">
+            <string>OTA enabled</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="checkBoxAdvanced">
+           <property name="text">
+            <string>Show advanced settings</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout_2">
          <item>
           <widget class="QLabel" name="label_10">
            <property name="text">
-            <string>Otau File</string>
+            <string>Select file</string>
            </property>
            <property name="buddy">
             <cstring>ou_fileEdit</cstring>
@@ -65,221 +93,232 @@
         </layout>
        </item>
        <item>
-        <layout class="QGridLayout" name="gridLayout_2">
-         <item row="0" column="0">
-          <widget class="QLabel" name="label_11">
-           <property name="text">
-            <string>Manufacturer Id</string>
-           </property>
-           <property name="buddy">
-            <cstring>ou_manufacturerEdit</cstring>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QLineEdit" name="ou_manufacturerEdit">
-           <property name="inputMask">
-            <string>\0\xHHHHHHHH</string>
-           </property>
-           <property name="text">
-            <string>0x0000</string>
-           </property>
-           <property name="readOnly">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="2">
-          <widget class="QLabel" name="label_2">
-           <property name="text">
-            <string>Image Type</string>
-           </property>
-           <property name="buddy">
-            <cstring>ou_imageTypeEdit</cstring>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="3" colspan="2">
-          <widget class="QLineEdit" name="ou_imageTypeEdit">
-           <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The otau client might use the image type as additional filter to accept or deny a otau image.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-           </property>
-           <property name="inputMask">
-            <string>\0\xHHHHHHHH</string>
-           </property>
-           <property name="text">
-            <string>0x0000</string>
-           </property>
-           <property name="readOnly">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QLabel" name="label">
-           <property name="text">
-            <string>File Version</string>
-           </property>
-           <property name="buddy">
-            <cstring>ou_fileVersionEdit</cstring>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="QLineEdit" name="ou_fileVersionEdit">
-           <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-           </property>
-           <property name="inputMask">
-            <string>\0\xHHHHHHHH</string>
-           </property>
-           <property name="text">
-            <string>0x00000000</string>
-           </property>
-           <property name="readOnly">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="2">
-          <widget class="QLabel" name="label_12">
-           <property name="text">
-            <string>Size</string>
-           </property>
-           <property name="buddy">
-            <cstring>ou_SizeEdit</cstring>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="3" colspan="2">
-          <widget class="QLineEdit" name="ou_SizeEdit">
-           <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Size of OTAU file including header.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-           </property>
-           <property name="text">
-            <string>0x00000000</string>
-           </property>
-           <property name="readOnly">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0">
-          <widget class="QCheckBox" name="restartAfterUpgradeCheckbox">
-           <property name="enabled">
-            <bool>true</bool>
-           </property>
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Restart After Upgrade</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="0">
-          <widget class="QLabel" name="label_13">
-           <property name="text">
-            <string>Last Image Query</string>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="1">
-          <widget class="QLabel" name="lastQueryLabel">
-           <property name="text">
-            <string>00:00:00</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="4">
-          <widget class="QCheckBox" name="useAcksCheckBox">
-           <property name="enabled">
-            <bool>true</bool>
-           </property>
-           <property name="text">
-            <string>Use ACKs</string>
-           </property>
-           <property name="checked">
-            <bool>false</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="4">
-          <widget class="QCheckBox" name="usePageRequestCheckBox">
-           <property name="text">
-            <string>Page Request</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="1">
-          <widget class="QSpinBox" name="restartAfterUpgradeSpinBox">
-           <property name="enabled">
-            <bool>true</bool>
-           </property>
-           <property name="suffix">
-            <string> s</string>
-           </property>
-           <property name="maximum">
-            <number>3600</number>
-           </property>
-           <property name="value">
-            <number>5</number>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="1">
-          <widget class="QSpinBox" name="spacingSpinBox">
-           <property name="suffix">
-            <string> ms</string>
-           </property>
-           <property name="prefix">
-            <string/>
-           </property>
-           <property name="minimum">
-            <number>4</number>
-           </property>
-           <property name="maximum">
-            <number>8000</number>
-           </property>
-           <property name="value">
-            <number>100</number>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="0">
-          <widget class="QLabel" name="label_14">
-           <property name="text">
-            <string>Packet Spacing</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
+        <widget class="QWidget" name="widgetAdvanced" native="true">
+         <layout class="QGridLayout" name="gridLayout">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <item row="3" column="3">
+           <widget class="QCheckBox" name="useAcksCheckBox">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="text">
+             <string>Use ACKs</string>
+            </property>
+            <property name="checked">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_11">
+            <property name="text">
+             <string>Manufacturer Id</string>
+            </property>
+            <property name="buddy">
+             <cstring>ou_manufacturerEdit</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="2">
+           <widget class="QLabel" name="label_12">
+            <property name="text">
+             <string>Size</string>
+            </property>
+            <property name="buddy">
+             <cstring>ou_SizeEdit</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>File Version</string>
+            </property>
+            <property name="buddy">
+             <cstring>ou_fileVersionEdit</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QLabel" name="lastQueryLabel">
+            <property name="text">
+             <string>00:00:00</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="3">
+           <widget class="QLineEdit" name="ou_imageTypeEdit">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The otau client might use the image type as additional filter to accept or deny a otau image.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="inputMask">
+             <string>\0\xHHHHHHHH</string>
+            </property>
+            <property name="text">
+             <string>0x0000</string>
+            </property>
+            <property name="readOnly">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLineEdit" name="ou_manufacturerEdit">
+            <property name="inputMask">
+             <string>\0\xHHHHHHHH</string>
+            </property>
+            <property name="text">
+             <string>0x0000</string>
+            </property>
+            <property name="readOnly">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="QSpinBox" name="spacingSpinBox">
+            <property name="suffix">
+             <string> ms</string>
+            </property>
+            <property name="prefix">
+             <string/>
+            </property>
+            <property name="minimum">
+             <number>4</number>
+            </property>
+            <property name="maximum">
+             <number>8000</number>
+            </property>
+            <property name="value">
+             <number>100</number>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="3">
+           <widget class="QCheckBox" name="usePageRequestCheckBox">
+            <property name="text">
+             <string>Page Request</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QSpinBox" name="restartAfterUpgradeSpinBox">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="suffix">
+             <string> s</string>
+            </property>
+            <property name="maximum">
+             <number>3600</number>
+            </property>
+            <property name="value">
+             <number>5</number>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QCheckBox" name="restartAfterUpgradeCheckbox">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Restart After Upgrade</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2">
+           <widget class="QLabel" name="label_2">
+            <property name="text">
+             <string>Image Type</string>
+            </property>
+            <property name="buddy">
+             <cstring>ou_imageTypeEdit</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="label_14">
+            <property name="text">
+             <string>Packet Spacing</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="3">
+           <widget class="QLineEdit" name="ou_SizeEdit">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Size of OTAU file including header.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>0x00000000</string>
+            </property>
+            <property name="readOnly">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QLineEdit" name="ou_fileVersionEdit">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="inputMask">
+             <string>\0\xHHHHHHHH</string>
+            </property>
+            <property name="text">
+             <string>0x00000000</string>
+            </property>
+            <property name="readOnly">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="label_13">
+            <property name="text">
+             <string>Last Image Query</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
        </item>
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout">
          <item>
-          <widget class="QLabel" name="labelOtauState">
+          <widget class="QPushButton" name="ou_checkOnlineButton">
+           <property name="toolTip">
+            <string>Check and download new OTA files if available.</string>
+           </property>
            <property name="text">
-            <string>OTAU enabled</string>
+            <string>Check online</string>
            </property>
           </widget>
          </item>
          <item>
           <spacer name="horizontalSpacer">
            <property name="orientation">
-            <enum>Qt::Horizontal</enum>
+            <enum>Qt::Orientation::Horizontal</enum>
            </property>
            <property name="sizeType">
-            <enum>QSizePolicy::MinimumExpanding</enum>
+            <enum>QSizePolicy::Policy::MinimumExpanding</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -295,7 +334,7 @@
             <bool>true</bool>
            </property>
            <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Requests the selected node to query for new update image.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            <string>Requests the selected node to query for new update image.</string>
            </property>
            <property name="text">
             <string>Query</string>
@@ -305,7 +344,7 @@
          <item>
           <widget class="QPushButton" name="ou_abortButton">
            <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Aborts update for selected node.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            <string>Aborts update for selected node.</string>
            </property>
            <property name="text">
             <string>Abort</string>
@@ -315,7 +354,7 @@
          <item>
           <widget class="QPushButton" name="ou_updateButton">
            <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Starts update for selected node. File must be chosen first.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            <string>Starts update for selected node. File must be chosen first.</string>
            </property>
            <property name="text">
             <string>Update</string>
@@ -327,10 +366,10 @@
        <item>
         <widget class="QTableView" name="tableView">
          <property name="selectionMode">
-          <enum>QAbstractItemView::SingleSelection</enum>
+          <enum>QAbstractItemView::SelectionMode::SingleSelection</enum>
          </property>
          <property name="selectionBehavior">
-          <enum>QAbstractItemView::SelectRows</enum>
+          <enum>QAbstractItemView::SelectionBehavior::SelectRows</enum>
          </property>
          <attribute name="horizontalHeaderStretchLastSection">
           <bool>true</bool>
@@ -344,7 +383,7 @@
      </widget>
      <widget class="QWidget" name="tab_2">
       <attribute name="title">
-       <string>OTAU File</string>
+       <string>File editor</string>
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_3">
        <item>
@@ -537,22 +576,5 @@
   </layout>
  </widget>
  <resources/>
- <connections>
-  <connection>
-   <sender>restartAfterUpgradeCheckbox</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>restartAfterUpgradeSpinBox</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>148</x>
-     <y>131</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>201</x>
-     <y>133</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>


### PR DESCRIPTION
## Simplified UI for OTA updates

The main OTA widget now hides less important information behind a **Show advanced settings** checkbox.

<img width="633" height="396" alt="grafik" src="https://github.com/user-attachments/assets/5d77ca15-66a2-4ad2-8101-4bf867b2fa1b" />

-----

There is a new **OTA Update** button in the main window toolbar, on the left next to the "Phoscon App" button.
Clicking on it automatically opens the *OTA Update* panel.

In former versions this was rather cumbersome, instead of one click it was:
- Click on "Panels" in the menu
- Click on "OTA Update" in the panels menu
- Click on "OTA Update" in the on the bottom panels tab widget to actually see the OTA Update panel

<img width="854" height="392" alt="grafik" src="https://github.com/user-attachments/assets/899c7b26-865f-4c2f-a4b0-8acffc128a46" />



## Support for downloading OTA files from a JSON based registry

Prior to this PR OTA files needed to be downloaded manually and put in the `$HOME/otau`directory. The PR adds support to do this with just one click.

By default OTA files are optained from the well maintained [Koenkk/zigbee-OTA](https://github.com/koenkk/zigbee-ota) JSON index which contains links to the original file URLs as well as a GitHub based mirror (in case the original URLs go mia).

The default URL is:

https://raw.githubusercontent.com/Koenkk/zigbee-OTA/refs/heads/master/index.json

It can also be overwritten in the config.ini:

```
[otau]
online-url=https://mirrow/index.json
```

- The check for new updates is never done automatically
- The initial load of the `index.json` is done, once clicking the **Check online** button
- This also triggers a *OTA Image Notify Request* to the selected node to optain the currently installed firmware version, image type, etc.
- If there is a newer version available for the device the status will show "Update available" in the progress column
- Then after pressing **Update** button the update gets "Queued" and should start shortly after that
- End-devices often need to be woken up manually by button press or similar means
- Note: after the initial download of the index file updates will also be shown for other devices in case the OTA image type and manufacturer code is known (many devices query the OTA server periodically, such as Hue devices).

Already existing OTA files won't be redownloaded again, since all local files are indexes on their SHA-512 checksum and compared against the SHA-512 in the `index.json` file.

Currently this only supports convenient updates, for downgrades the prior manual approach of selecting a file on disk must be taken, in future this will be added to the UI to be more easy, ala selecting the version from a list.

